### PR TITLE
[Feature] Enhanced CSV/Excel import with auto-detection

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,10 +1,16 @@
+// Package importer provides CSV and Excel import functionality for part lists.
+// It supports automatic delimiter detection, flexible column mapping, and
+// case-insensitive header recognition.
 package importer
 
 import (
+	"bytes"
 	"encoding/csv"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/piwi3910/cnc-calculator/internal/model"
 	"github.com/xuri/excelize/v2"
@@ -17,20 +23,247 @@ type ImportResult struct {
 	Warnings []string
 }
 
+// ColumnMapping maps semantic column roles to their indices in the data.
+type ColumnMapping struct {
+	Label    int
+	Width    int
+	Height   int
+	Quantity int
+	Grain    int
+}
+
+// headerAliases maps canonical column names to their accepted aliases (all lowercase).
+var headerAliases = map[string][]string{
+	"label":    {"label", "name", "part", "part name", "description", "desc", "piece", "item"},
+	"width":    {"width", "w", "length", "len", "x"},
+	"height":   {"height", "h", "depth", "d", "y"},
+	"quantity": {"quantity", "qty", "count", "num", "amount", "pcs", "pieces"},
+	"grain":    {"grain", "grain direction", "direction", "grain dir", "orientation"},
+}
+
+// DetectCSVDelimiter reads the file content and determines the most likely CSV delimiter.
+// It tries comma, semicolon, tab, and pipe. The delimiter that produces the most
+// consistent (non-one) column count across lines wins.
+func DetectCSVDelimiter(data []byte) rune {
+	candidates := []rune{',', ';', '\t', '|'}
+	bestDelimiter := ','
+	bestScore := 0
+
+	for _, delim := range candidates {
+		reader := csv.NewReader(bytes.NewReader(data))
+		reader.Comma = delim
+		reader.LazyQuotes = true
+		reader.FieldsPerRecord = -1 // Allow variable field counts
+
+		records, err := reader.ReadAll()
+		if err != nil || len(records) < 1 {
+			continue
+		}
+
+		// Score: count how many rows have the same column count as the first row
+		// Only consider delimiters that produce more than 1 column
+		firstCols := len(records[0])
+		if firstCols < 2 {
+			continue
+		}
+
+		score := 0
+		for _, row := range records {
+			if len(row) == firstCols {
+				score++
+			}
+		}
+
+		// Prefer delimiters with higher consistency and more columns
+		weighted := score*10 + firstCols
+		if weighted > bestScore {
+			bestScore = weighted
+			bestDelimiter = delim
+		}
+	}
+
+	return bestDelimiter
+}
+
+// DetectColumns examines a header row and returns a ColumnMapping.
+// It performs case-insensitive matching against known aliases for each column role.
+// Returns the mapping and true if a header was detected, or a default positional
+// mapping and false if no header was found.
+func DetectColumns(row []string) (ColumnMapping, bool) {
+	mapping := ColumnMapping{
+		Label:    -1,
+		Width:    -1,
+		Height:   -1,
+		Quantity: -1,
+		Grain:    -1,
+	}
+
+	isHeader := false
+	for i, cell := range row {
+		normalized := strings.ToLower(strings.TrimSpace(cell))
+		for role, aliases := range headerAliases {
+			for _, alias := range aliases {
+				if normalized == alias {
+					isHeader = true
+					switch role {
+					case "label":
+						if mapping.Label == -1 {
+							mapping.Label = i
+						}
+					case "width":
+						if mapping.Width == -1 {
+							mapping.Width = i
+						}
+					case "height":
+						if mapping.Height == -1 {
+							mapping.Height = i
+						}
+					case "quantity":
+						if mapping.Quantity == -1 {
+							mapping.Quantity = i
+						}
+					case "grain":
+						if mapping.Grain == -1 {
+							mapping.Grain = i
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if !isHeader {
+		// Fall back to positional mapping: Label, Width, Height, Quantity, Grain
+		return ColumnMapping{
+			Label:    0,
+			Width:    1,
+			Height:   2,
+			Quantity: 3,
+			Grain:    4,
+		}, false
+	}
+
+	return mapping, true
+}
+
+// parseGrain converts a grain direction string to a model.Grain value.
+// It returns the grain value and a boolean indicating whether the string was recognized.
+func parseGrain(s string) (model.Grain, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "horizontal", "h":
+		return model.GrainHorizontal, true
+	case "vertical", "v":
+		return model.GrainVertical, true
+	case "", "none", "n", "-":
+		return model.GrainNone, true
+	default:
+		return model.GrainNone, false
+	}
+}
+
+// getCell safely retrieves a cell value from a row by column index.
+// Returns empty string if the index is out of range or negative.
+func getCell(row []string, idx int) string {
+	if idx < 0 || idx >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[idx])
+}
+
+// parseRow extracts a Part from a row using the given column mapping.
+// Returns the part, any error message, and any warning message.
+func parseRow(row []string, mapping ColumnMapping, rowLabel string, partCount int) (model.Part, string, string) {
+	label := getCell(row, mapping.Label)
+	if label == "" {
+		label = fmt.Sprintf("Part %d", partCount+1)
+	}
+
+	widthStr := getCell(row, mapping.Width)
+	if widthStr == "" {
+		return model.Part{}, fmt.Sprintf("%s: Missing width value", rowLabel), ""
+	}
+	width, err := strconv.ParseFloat(widthStr, 64)
+	if err != nil {
+		return model.Part{}, fmt.Sprintf("%s: Invalid width '%s'", rowLabel, widthStr), ""
+	}
+
+	heightStr := getCell(row, mapping.Height)
+	if heightStr == "" {
+		return model.Part{}, fmt.Sprintf("%s: Missing height value", rowLabel), ""
+	}
+	height, err := strconv.ParseFloat(heightStr, 64)
+	if err != nil {
+		return model.Part{}, fmt.Sprintf("%s: Invalid height '%s'", rowLabel, heightStr), ""
+	}
+
+	qtyStr := getCell(row, mapping.Quantity)
+	if qtyStr == "" {
+		return model.Part{}, fmt.Sprintf("%s: Missing quantity value", rowLabel), ""
+	}
+	qty, err := strconv.Atoi(qtyStr)
+	if err != nil {
+		return model.Part{}, fmt.Sprintf("%s: Invalid quantity '%s'", rowLabel, qtyStr), ""
+	}
+
+	if width <= 0 || height <= 0 || qty <= 0 {
+		return model.Part{}, fmt.Sprintf("%s: Width, height, and quantity must be positive", rowLabel), ""
+	}
+
+	part := model.NewPart(label, width, height, qty)
+
+	// Optional grain direction
+	var warning string
+	grainStr := getCell(row, mapping.Grain)
+	if grainStr != "" {
+		grain, ok := parseGrain(grainStr)
+		if ok {
+			part.Grain = grain
+		} else {
+			warning = fmt.Sprintf("%s: Unknown grain direction '%s', defaulting to None", rowLabel, grainStr)
+		}
+	}
+
+	return part, "", warning
+}
+
+// isEmptyRow returns true if the row has no meaningful content.
+func isEmptyRow(row []string) bool {
+	for _, cell := range row {
+		if strings.TrimSpace(cell) != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // ImportCSV imports parts from a CSV file.
-// Expected format: Label, Width, Height, Quantity, Grain (optional)
-// Returns a slice of Part objects and any errors encountered.
+// It automatically detects the delimiter and maps columns by header names.
+// Supports comma, semicolon, tab, and pipe delimiters.
 func ImportCSV(path string) ImportResult {
 	result := ImportResult{}
 
-	file, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Cannot open file: %v", err))
 		return result
 	}
-	defer file.Close()
 
-	reader := csv.NewReader(file)
+	if len(bytes.TrimSpace(data)) == 0 {
+		result.Errors = append(result.Errors, "File is empty")
+		return result
+	}
+
+	delimiter := DetectCSVDelimiter(data)
+	if delimiter != ',' {
+		delimName := map[rune]string{';': "semicolon", '\t': "tab", '|': "pipe"}[delimiter]
+		result.Warnings = append(result.Warnings, fmt.Sprintf("Detected %s delimiter", delimName))
+	}
+
+	reader := csv.NewReader(bytes.NewReader(data))
+	reader.Comma = delimiter
+	reader.LazyQuotes = true
+	reader.FieldsPerRecord = -1
+
 	records, err := reader.ReadAll()
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Cannot read CSV: %v", err))
@@ -42,87 +275,36 @@ func ImportCSV(path string) ImportResult {
 		return result
 	}
 
-	// Skip header row if it exists
-	startRow := 0
-	if len(records) > 0 {
-		firstRow := records[0]
-		if len(firstRow) >= 3 {
-			// Check if first row looks like a header (non-numeric values)
-			if _, err := strconv.ParseFloat(firstRow[1], 64); err != nil {
-				startRow = 1 // Skip header
-				result.Warnings = append(result.Warnings, "Detected header row, skipping")
-			}
-		}
-	}
-
-	lineNum := startRow + 1
-	for i := startRow; i < len(records); i++ {
-		row := records[i]
-		lineNum++
-
-		// Skip empty rows
-		if len(row) == 0 || (len(row) == 1 && row[0] == "") {
-			continue
-		}
-
-		if len(row) < 4 {
-			result.Errors = append(result.Errors, fmt.Sprintf("Line %d: Not enough columns (need at least: Label, Width, Height, Quantity)", lineNum))
-			continue
-		}
-
-		label := row[0]
-		if label == "" {
-			label = fmt.Sprintf("Part %d", len(result.Parts)+1)
-		}
-
-		width, err := strconv.ParseFloat(row[1], 64)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Line %d: Invalid width '%s'", lineNum, row[1]))
-			continue
-		}
-
-		height, err := strconv.ParseFloat(row[2], 64)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Line %d: Invalid height '%s'", lineNum, row[2]))
-			continue
-		}
-
-		qty, err := strconv.Atoi(row[3])
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Line %d: Invalid quantity '%s'", lineNum, row[3]))
-			continue
-		}
-
-		if width <= 0 || height <= 0 || qty <= 0 {
-			result.Errors = append(result.Errors, fmt.Sprintf("Line %d: Width, height, and quantity must be positive", lineNum))
-			continue
-		}
-
-		part := model.NewPart(label, width, height, qty)
-
-		// Optional grain direction
-		if len(row) >= 5 {
-			grainStr := row[4]
-			switch grainStr {
-			case "Horizontal", "H", "h":
-				part.Grain = model.GrainHorizontal
-			case "Vertical", "V", "v":
-				part.Grain = model.GrainVertical
-			case "", "None", "N", "n":
-				part.Grain = model.GrainNone
-			default:
-				result.Warnings = append(result.Warnings, fmt.Sprintf("Line %d: Unknown grain direction '%s', defaulting to None", lineNum, grainStr))
-			}
-		}
-
-		result.Parts = append(result.Parts, part)
-	}
-
+	result = importFromRows(records, "Line", result.Warnings)
 	return result
 }
 
+// ImportCSVFromReader imports parts from a CSV reader with a specific delimiter.
+// This is useful for testing or when the delimiter is already known.
+func ImportCSVFromReader(reader io.Reader, delimiter rune) ImportResult {
+	result := ImportResult{}
+
+	csvReader := csv.NewReader(reader)
+	csvReader.Comma = delimiter
+	csvReader.LazyQuotes = true
+	csvReader.FieldsPerRecord = -1
+
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Cannot read CSV: %v", err))
+		return result
+	}
+
+	if len(records) == 0 {
+		result.Errors = append(result.Errors, "File is empty")
+		return result
+	}
+
+	return importFromRows(records, "Line", nil)
+}
+
 // ImportExcel imports parts from an Excel (.xlsx, .xls) file.
-// Reads the first sheet, expected format: Label, Width, Height, Quantity, Grain (optional)
+// Reads the first sheet and auto-detects column mapping from headers.
 func ImportExcel(path string) ImportResult {
 	result := ImportResult{}
 
@@ -133,14 +315,12 @@ func ImportExcel(path string) ImportResult {
 	}
 	defer f.Close()
 
-	// Get the first sheet
 	sheets := f.GetSheetList()
 	if len(sheets) == 0 {
 		result.Errors = append(result.Errors, "Excel file has no sheets")
 		return result
 	}
 
-	// Read all rows from first sheet
 	rows, err := f.GetRows(sheets[0])
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Cannot read Excel data: %v", err))
@@ -152,74 +332,72 @@ func ImportExcel(path string) ImportResult {
 		return result
 	}
 
-	// Detect and skip header
+	return importFromRows(rows, "Row", nil)
+}
+
+// importFromRows is the shared import logic for both CSV and Excel data.
+// It detects headers, maps columns, and parses each row into parts.
+func importFromRows(rows [][]string, rowPrefix string, initialWarnings []string) ImportResult {
+	result := ImportResult{
+		Warnings: initialWarnings,
+	}
+
+	if len(rows) == 0 {
+		result.Errors = append(result.Errors, "No data rows found")
+		return result
+	}
+
+	// Detect columns from first row
+	mapping, hasHeader := DetectColumns(rows[0])
 	startRow := 0
-	if len(rows) > 1 && len(rows[0]) >= 3 {
-		// Check if first row looks like a header
-		if _, err := strconv.ParseFloat(rows[0][1], 64); err != nil {
-			startRow = 1
-			result.Warnings = append(result.Warnings, "Detected header row, skipping")
+	if hasHeader {
+		startRow = 1
+		result.Warnings = append(result.Warnings, "Detected header row, skipping")
+
+		// Validate that required columns were found
+		missing := []string{}
+		if mapping.Width == -1 {
+			missing = append(missing, "Width")
+		}
+		if mapping.Height == -1 {
+			missing = append(missing, "Height")
+		}
+		if mapping.Quantity == -1 {
+			missing = append(missing, "Quantity")
+		}
+		if len(missing) > 0 {
+			result.Errors = append(result.Errors, fmt.Sprintf("Required columns not found in header: %s", strings.Join(missing, ", ")))
+			return result
+		}
+	} else {
+		// No header: check if first row is numeric (positional mapping)
+		if len(rows[0]) >= 3 {
+			if _, err := strconv.ParseFloat(strings.TrimSpace(rows[0][1]), 64); err != nil {
+				// First column after label is not numeric - might be an unrecognized header
+				// Skip it as a header but use positional mapping
+				startRow = 1
+				result.Warnings = append(result.Warnings, "Detected header row, skipping")
+			}
 		}
 	}
 
-	lineNum := startRow + 1
 	for i := startRow; i < len(rows); i++ {
 		row := rows[i]
-		lineNum++
+		lineNum := i + 1
 
-		// Skip empty rows
-		if len(row) == 0 || (len(row) == 1 && row[0] == "") {
+		if isEmptyRow(row) {
 			continue
 		}
 
-		if len(row) < 4 {
-			result.Errors = append(result.Errors, fmt.Sprintf("Row %d: Not enough columns (need at least: Label, Width, Height, Quantity)", lineNum))
+		rowLabel := fmt.Sprintf("%s %d", rowPrefix, lineNum)
+		part, errMsg, warning := parseRow(row, mapping, rowLabel, len(result.Parts))
+
+		if errMsg != "" {
+			result.Errors = append(result.Errors, errMsg)
 			continue
 		}
-
-		label := row[0]
-		if label == "" {
-			label = fmt.Sprintf("Part %d", len(result.Parts)+1)
-		}
-
-		width, err := strconv.ParseFloat(row[1], 64)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Row %d: Invalid width '%s'", lineNum, row[1]))
-			continue
-		}
-
-		height, err := strconv.ParseFloat(row[2], 64)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Row %d: Invalid height '%s'", lineNum, row[2]))
-			continue
-		}
-
-		qty, err := strconv.Atoi(row[3])
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Row %d: Invalid quantity '%s'", lineNum, row[3]))
-			continue
-		}
-
-		if width <= 0 || height <= 0 || qty <= 0 {
-			result.Errors = append(result.Errors, fmt.Sprintf("Row %d: Width, height, and quantity must be positive", lineNum))
-			continue
-		}
-
-		part := model.NewPart(label, width, height, qty)
-
-		// Optional grain direction
-		if len(row) >= 5 {
-			grainStr := row[4]
-			switch grainStr {
-			case "Horizontal", "H", "h":
-				part.Grain = model.GrainHorizontal
-			case "Vertical", "V", "v":
-				part.Grain = model.GrainVertical
-			case "", "None", "N", "n":
-				part.Grain = model.GrainNone
-			default:
-				result.Warnings = append(result.Warnings, fmt.Sprintf("Row %d: Unknown grain direction '%s', defaulting to None", lineNum, grainStr))
-			}
+		if warning != "" {
+			result.Warnings = append(result.Warnings, warning)
 		}
 
 		result.Parts = append(result.Parts, part)

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -1,0 +1,651 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/piwi3910/cnc-calculator/internal/model"
+	"github.com/xuri/excelize/v2"
+)
+
+// ─── DetectCSVDelimiter Tests ──────────────────────────────
+
+func TestDetectCSVDelimiter_Comma(t *testing.T) {
+	data := []byte("Label,Width,Height,Qty\nShelf,600,300,2\nDoor,400,800,1\n")
+	got := DetectCSVDelimiter(data)
+	if got != ',' {
+		t.Errorf("expected comma delimiter, got %q", got)
+	}
+}
+
+func TestDetectCSVDelimiter_Semicolon(t *testing.T) {
+	data := []byte("Label;Width;Height;Qty\nShelf;600;300;2\nDoor;400;800;1\n")
+	got := DetectCSVDelimiter(data)
+	if got != ';' {
+		t.Errorf("expected semicolon delimiter, got %q", got)
+	}
+}
+
+func TestDetectCSVDelimiter_Tab(t *testing.T) {
+	data := []byte("Label\tWidth\tHeight\tQty\nShelf\t600\t300\t2\nDoor\t400\t800\t1\n")
+	got := DetectCSVDelimiter(data)
+	if got != '\t' {
+		t.Errorf("expected tab delimiter, got %q", got)
+	}
+}
+
+func TestDetectCSVDelimiter_Pipe(t *testing.T) {
+	data := []byte("Label|Width|Height|Qty\nShelf|600|300|2\nDoor|400|800|1\n")
+	got := DetectCSVDelimiter(data)
+	if got != '|' {
+		t.Errorf("expected pipe delimiter, got %q", got)
+	}
+}
+
+// ─── DetectColumns Tests ───────────────────────────────────
+
+func TestDetectColumns_StandardHeaders(t *testing.T) {
+	row := []string{"Label", "Width", "Height", "Quantity", "Grain"}
+	mapping, isHeader := DetectColumns(row)
+
+	if !isHeader {
+		t.Error("expected header to be detected")
+	}
+	if mapping.Label != 0 {
+		t.Errorf("expected Label at 0, got %d", mapping.Label)
+	}
+	if mapping.Width != 1 {
+		t.Errorf("expected Width at 1, got %d", mapping.Width)
+	}
+	if mapping.Height != 2 {
+		t.Errorf("expected Height at 2, got %d", mapping.Height)
+	}
+	if mapping.Quantity != 3 {
+		t.Errorf("expected Quantity at 3, got %d", mapping.Quantity)
+	}
+	if mapping.Grain != 4 {
+		t.Errorf("expected Grain at 4, got %d", mapping.Grain)
+	}
+}
+
+func TestDetectColumns_CaseInsensitive(t *testing.T) {
+	row := []string{"NAME", "WIDTH", "HEIGHT", "QTY", "GRAIN"}
+	mapping, isHeader := DetectColumns(row)
+
+	if !isHeader {
+		t.Error("expected header to be detected")
+	}
+	if mapping.Label != 0 {
+		t.Errorf("expected Label at 0, got %d", mapping.Label)
+	}
+	if mapping.Width != 1 {
+		t.Errorf("expected Width at 1, got %d", mapping.Width)
+	}
+}
+
+func TestDetectColumns_AlternativeNames(t *testing.T) {
+	row := []string{"Part Name", "W", "H", "Pcs", "Direction"}
+	mapping, isHeader := DetectColumns(row)
+
+	if !isHeader {
+		t.Error("expected header to be detected")
+	}
+	if mapping.Label != 0 {
+		t.Errorf("expected Label at 0, got %d", mapping.Label)
+	}
+	if mapping.Width != 1 {
+		t.Errorf("expected Width at 1, got %d", mapping.Width)
+	}
+	if mapping.Height != 2 {
+		t.Errorf("expected Height at 2, got %d", mapping.Height)
+	}
+	if mapping.Quantity != 3 {
+		t.Errorf("expected Quantity at 3, got %d", mapping.Quantity)
+	}
+	if mapping.Grain != 4 {
+		t.Errorf("expected Grain at 4, got %d", mapping.Grain)
+	}
+}
+
+func TestDetectColumns_ReorderedColumns(t *testing.T) {
+	row := []string{"Qty", "Height", "Width", "Label"}
+	mapping, isHeader := DetectColumns(row)
+
+	if !isHeader {
+		t.Error("expected header to be detected")
+	}
+	if mapping.Quantity != 0 {
+		t.Errorf("expected Quantity at 0, got %d", mapping.Quantity)
+	}
+	if mapping.Height != 1 {
+		t.Errorf("expected Height at 1, got %d", mapping.Height)
+	}
+	if mapping.Width != 2 {
+		t.Errorf("expected Width at 2, got %d", mapping.Width)
+	}
+	if mapping.Label != 3 {
+		t.Errorf("expected Label at 3, got %d", mapping.Label)
+	}
+}
+
+func TestDetectColumns_NoHeader(t *testing.T) {
+	row := []string{"Shelf", "600", "300", "2"}
+	mapping, isHeader := DetectColumns(row)
+
+	if isHeader {
+		t.Error("expected no header detection for numeric data")
+	}
+	// Should fall back to positional
+	if mapping.Label != 0 || mapping.Width != 1 || mapping.Height != 2 || mapping.Quantity != 3 {
+		t.Errorf("expected positional mapping, got %+v", mapping)
+	}
+}
+
+// ─── CSV Import Tests ──────────────────────────────────────
+
+func TestImportCSVFromReader_WithHeaders(t *testing.T) {
+	data := "Label,Width,Height,Quantity,Grain\nShelf,600,300,2,Horizontal\nDoor,400,800,1,Vertical\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(result.Parts))
+	}
+
+	if result.Parts[0].Label != "Shelf" {
+		t.Errorf("expected label 'Shelf', got '%s'", result.Parts[0].Label)
+	}
+	if result.Parts[0].Width != 600 {
+		t.Errorf("expected width 600, got %f", result.Parts[0].Width)
+	}
+	if result.Parts[0].Height != 300 {
+		t.Errorf("expected height 300, got %f", result.Parts[0].Height)
+	}
+	if result.Parts[0].Quantity != 2 {
+		t.Errorf("expected quantity 2, got %d", result.Parts[0].Quantity)
+	}
+	if result.Parts[0].Grain != model.GrainHorizontal {
+		t.Errorf("expected GrainHorizontal, got %v", result.Parts[0].Grain)
+	}
+
+	if result.Parts[1].Grain != model.GrainVertical {
+		t.Errorf("expected GrainVertical, got %v", result.Parts[1].Grain)
+	}
+}
+
+func TestImportCSVFromReader_WithoutHeaders(t *testing.T) {
+	data := "Shelf,600,300,2\nDoor,400,800,1\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d (errors: %v)", len(result.Parts), result.Errors)
+	}
+	if result.Parts[0].Label != "Shelf" {
+		t.Errorf("expected label 'Shelf', got '%s'", result.Parts[0].Label)
+	}
+	if result.Parts[0].Width != 600 {
+		t.Errorf("expected width 600, got %f", result.Parts[0].Width)
+	}
+}
+
+func TestImportCSVFromReader_SemicolonDelimiter(t *testing.T) {
+	data := "Label;Width;Height;Quantity\nShelf;600;300;2\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ';')
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+	if result.Parts[0].Label != "Shelf" {
+		t.Errorf("expected label 'Shelf', got '%s'", result.Parts[0].Label)
+	}
+}
+
+func TestImportCSVFromReader_TabDelimiter(t *testing.T) {
+	data := "Label\tWidth\tHeight\tQuantity\nShelf\t600\t300\t2\n"
+	result := ImportCSVFromReader(strings.NewReader(data), '\t')
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+}
+
+func TestImportCSVFromReader_ReorderedColumns(t *testing.T) {
+	data := "Qty,Height,Width,Name\n2,300,600,Shelf\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+	if result.Parts[0].Label != "Shelf" {
+		t.Errorf("expected label 'Shelf', got '%s'", result.Parts[0].Label)
+	}
+	if result.Parts[0].Width != 600 {
+		t.Errorf("expected width 600, got %f", result.Parts[0].Width)
+	}
+	if result.Parts[0].Height != 300 {
+		t.Errorf("expected height 300, got %f", result.Parts[0].Height)
+	}
+	if result.Parts[0].Quantity != 2 {
+		t.Errorf("expected quantity 2, got %d", result.Parts[0].Quantity)
+	}
+}
+
+func TestImportCSVFromReader_EmptyFile(t *testing.T) {
+	data := ""
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for empty file")
+	}
+}
+
+func TestImportCSVFromReader_InvalidWidth(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nShelf,abc,300,2\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for invalid width")
+	}
+	if len(result.Parts) != 0 {
+		t.Errorf("expected 0 parts, got %d", len(result.Parts))
+	}
+}
+
+func TestImportCSVFromReader_InvalidQuantity(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nShelf,600,300,abc\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for invalid quantity")
+	}
+}
+
+func TestImportCSVFromReader_NegativeValues(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nShelf,-600,300,2\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for negative width")
+	}
+}
+
+func TestImportCSVFromReader_ZeroQuantity(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nShelf,600,300,0\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for zero quantity")
+	}
+}
+
+func TestImportCSVFromReader_MixedValidAndInvalid(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nGood,600,300,2\nBad,abc,300,2\nAlsoGood,400,200,1\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 2 {
+		t.Errorf("expected 2 valid parts, got %d", len(result.Parts))
+	}
+	if len(result.Errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(result.Errors))
+	}
+}
+
+func TestImportCSVFromReader_EmptyRows(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nShelf,600,300,2\n\n\nDoor,400,800,1\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 2 {
+		t.Errorf("expected 2 parts (skipping empty rows), got %d (errors: %v)", len(result.Parts), result.Errors)
+	}
+}
+
+func TestImportCSVFromReader_EmptyLabel(t *testing.T) {
+	data := "Label,Width,Height,Quantity\n,600,300,2\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+	if result.Parts[0].Label != "Part 1" {
+		t.Errorf("expected auto-generated label 'Part 1', got '%s'", result.Parts[0].Label)
+	}
+}
+
+func TestImportCSVFromReader_GrainParsing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected model.Grain
+		warning  bool
+	}{
+		{"Horizontal", model.GrainHorizontal, false},
+		{"horizontal", model.GrainHorizontal, false},
+		{"H", model.GrainHorizontal, false},
+		{"h", model.GrainHorizontal, false},
+		{"Vertical", model.GrainVertical, false},
+		{"vertical", model.GrainVertical, false},
+		{"V", model.GrainVertical, false},
+		{"v", model.GrainVertical, false},
+		{"None", model.GrainNone, false},
+		{"none", model.GrainNone, false},
+		{"N", model.GrainNone, false},
+		{"n", model.GrainNone, false},
+		{"-", model.GrainNone, false},
+		{"", model.GrainNone, false},
+		{"diagonal", model.GrainNone, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			data := "Label,Width,Height,Quantity,Grain\nPart,600,300,1," + tt.input + "\n"
+			result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+			if len(result.Parts) != 1 {
+				t.Fatalf("expected 1 part, got %d (errors: %v)", len(result.Parts), result.Errors)
+			}
+			if result.Parts[0].Grain != tt.expected {
+				t.Errorf("grain %q: expected %v, got %v", tt.input, tt.expected, result.Parts[0].Grain)
+			}
+			hasWarning := false
+			for _, w := range result.Warnings {
+				if strings.Contains(w, "Unknown grain direction") {
+					hasWarning = true
+				}
+			}
+			if tt.warning && !hasWarning {
+				t.Errorf("grain %q: expected warning but got none", tt.input)
+			}
+			if !tt.warning && hasWarning {
+				t.Errorf("grain %q: unexpected warning", tt.input)
+			}
+		})
+	}
+}
+
+func TestImportCSVFromReader_MissingRequiredColumnInHeader(t *testing.T) {
+	data := "Label,Width,Grain\nShelf,600,H\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for missing Height and Quantity columns")
+	}
+	foundMissing := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "Required columns not found") {
+			foundMissing = true
+		}
+	}
+	if !foundMissing {
+		t.Errorf("expected 'Required columns not found' error, got: %v", result.Errors)
+	}
+}
+
+// ─── CSV File Import Tests ──────────────────────────────────
+
+func TestImportCSV_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "parts.csv")
+	content := "Label,Width,Height,Quantity\nShelf,600,300,2\nDoor,400,800,1\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := ImportCSV(path)
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(result.Parts))
+	}
+}
+
+func TestImportCSV_SemicolonFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "parts.csv")
+	content := "Label;Width;Height;Quantity\nShelf;600;300;2\nDoor;400;800;1\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := ImportCSV(path)
+
+	if len(result.Parts) != 2 {
+		t.Errorf("expected 2 parts, got %d (errors: %v)", len(result.Parts), result.Errors)
+	}
+
+	// Should have a warning about semicolon delimiter
+	hasSemicolonWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "semicolon") {
+			hasSemicolonWarning = true
+		}
+	}
+	if !hasSemicolonWarning {
+		t.Error("expected warning about semicolon delimiter detection")
+	}
+}
+
+func TestImportCSV_FileNotFound(t *testing.T) {
+	result := ImportCSV("/nonexistent/path/file.csv")
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestImportCSV_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.csv")
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := ImportCSV(path)
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for empty file")
+	}
+}
+
+// ─── Excel Import Tests ────────────────────────────────────
+
+func createTestExcel(t *testing.T, rows [][]interface{}) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "parts.xlsx")
+
+	f := excelize.NewFile()
+	sheet := f.GetSheetName(0)
+
+	for i, row := range rows {
+		for j, cell := range row {
+			cellRef, err := excelize.CoordinatesToCellName(j+1, i+1)
+			if err != nil {
+				t.Fatalf("failed to create cell reference: %v", err)
+			}
+			if err := f.SetCellValue(sheet, cellRef, cell); err != nil {
+				t.Fatalf("failed to set cell value: %v", err)
+			}
+		}
+	}
+
+	if err := f.SaveAs(path); err != nil {
+		t.Fatalf("failed to save Excel file: %v", err)
+	}
+	return path
+}
+
+func TestImportExcel_WithHeaders(t *testing.T) {
+	path := createTestExcel(t, [][]interface{}{
+		{"Label", "Width", "Height", "Quantity", "Grain"},
+		{"Shelf", 600, 300, 2, "Horizontal"},
+		{"Door", 400, 800, 1, "Vertical"},
+	})
+
+	result := ImportExcel(path)
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(result.Parts))
+	}
+
+	if result.Parts[0].Label != "Shelf" {
+		t.Errorf("expected 'Shelf', got '%s'", result.Parts[0].Label)
+	}
+	if result.Parts[0].Width != 600 {
+		t.Errorf("expected width 600, got %f", result.Parts[0].Width)
+	}
+	if result.Parts[0].Grain != model.GrainHorizontal {
+		t.Errorf("expected GrainHorizontal, got %v", result.Parts[0].Grain)
+	}
+}
+
+func TestImportExcel_WithoutHeaders(t *testing.T) {
+	path := createTestExcel(t, [][]interface{}{
+		{"Shelf", 600, 300, 2},
+		{"Door", 400, 800, 1},
+	})
+
+	result := ImportExcel(path)
+
+	if len(result.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d (errors: %v)", len(result.Parts), result.Errors)
+	}
+}
+
+func TestImportExcel_ReorderedColumns(t *testing.T) {
+	path := createTestExcel(t, [][]interface{}{
+		{"Qty", "Name", "Height", "Width"},
+		{2, "Shelf", 300, 600},
+	})
+
+	result := ImportExcel(path)
+
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+	if result.Parts[0].Label != "Shelf" {
+		t.Errorf("expected 'Shelf', got '%s'", result.Parts[0].Label)
+	}
+	if result.Parts[0].Width != 600 {
+		t.Errorf("expected width 600, got %f", result.Parts[0].Width)
+	}
+}
+
+func TestImportExcel_FileNotFound(t *testing.T) {
+	result := ImportExcel("/nonexistent/file.xlsx")
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestImportExcel_InvalidData(t *testing.T) {
+	path := createTestExcel(t, [][]interface{}{
+		{"Label", "Width", "Height", "Quantity"},
+		{"Shelf", "abc", 300, 2},
+	})
+
+	result := ImportExcel(path)
+
+	if len(result.Errors) == 0 {
+		t.Error("expected error for invalid width")
+	}
+}
+
+// ─── parseGrain Tests ──────────────────────────────────────
+
+func TestParseGrain(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected model.Grain
+		ok       bool
+	}{
+		{"Horizontal", model.GrainHorizontal, true},
+		{"horizontal", model.GrainHorizontal, true},
+		{"H", model.GrainHorizontal, true},
+		{"h", model.GrainHorizontal, true},
+		{"Vertical", model.GrainVertical, true},
+		{"vertical", model.GrainVertical, true},
+		{"V", model.GrainVertical, true},
+		{"v", model.GrainVertical, true},
+		{"None", model.GrainNone, true},
+		{"none", model.GrainNone, true},
+		{"N", model.GrainNone, true},
+		{"n", model.GrainNone, true},
+		{"-", model.GrainNone, true},
+		{"", model.GrainNone, true},
+		{"  h  ", model.GrainHorizontal, true},
+		{"unknown", model.GrainNone, false},
+		{"diagonal", model.GrainNone, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			grain, ok := parseGrain(tt.input)
+			if grain != tt.expected {
+				t.Errorf("parseGrain(%q): expected %v, got %v", tt.input, tt.expected, grain)
+			}
+			if ok != tt.ok {
+				t.Errorf("parseGrain(%q): expected ok=%v, got %v", tt.input, tt.ok, ok)
+			}
+		})
+	}
+}
+
+// ─── Edge Cases ────────────────────────────────────────────
+
+func TestImportCSVFromReader_OnlyHeaders(t *testing.T) {
+	data := "Label,Width,Height,Quantity\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 0 {
+		t.Errorf("expected 0 parts for header-only file, got %d", len(result.Parts))
+	}
+	// Should not have errors (just no data)
+}
+
+func TestImportCSVFromReader_WhitespaceInValues(t *testing.T) {
+	data := "Label , Width , Height , Quantity\n Shelf , 600 , 300 , 2 \n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d (errors: %v)", len(result.Parts), result.Errors)
+	}
+	if result.Parts[0].Width != 600 {
+		t.Errorf("expected width 600, got %f", result.Parts[0].Width)
+	}
+}
+
+func TestImportCSVFromReader_DecimalValues(t *testing.T) {
+	data := "Label,Width,Height,Quantity\nShelf,600.5,300.25,2\n"
+	result := ImportCSVFromReader(strings.NewReader(data), ',')
+
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d (errors: %v)", len(result.Parts), result.Errors)
+	}
+	if result.Parts[0].Width != 600.5 {
+		t.Errorf("expected width 600.5, got %f", result.Parts[0].Width)
+	}
+	if result.Parts[0].Height != 300.25 {
+		t.Errorf("expected height 300.25, got %f", result.Parts[0].Height)
+	}
+}


### PR DESCRIPTION
## Summary

- Add automatic CSV delimiter detection supporting comma, semicolon, tab, and pipe separators
- Add flexible column mapping with case-insensitive header recognition (supports aliases like "Name"/"Part"/"Label", "W"/"Width", "Qty"/"Count"/"Pieces", etc.)
- Support reordered columns — headers determine which column maps to which field
- Refactor CSV and Excel importers to share common parsing logic, eliminating code duplication
- Improve the import summary dialog in the UI to show parts imported, warnings, and errors in a single comprehensive view
- Add 37 comprehensive tests covering delimiter detection, header parsing, column reordering, grain direction parsing, error handling, edge cases, and Excel import

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/importer/` — all 37 tests pass
- [ ] Manual: Import a comma-delimited CSV with standard headers
- [ ] Manual: Import a semicolon-delimited CSV (European locale)
- [ ] Manual: Import a CSV with reordered columns
- [ ] Manual: Import an Excel file with headers
- [ ] Manual: Verify import summary dialog shows warnings and error counts

Resolves #6