### PR TITLE
[Feature] Undo/Redo for part and stock edits

### DIFF
--- a/internal/ui/history.go
+++ b/internal/ui/history.go
@@ -1,0 +1,118 @@
+package ui
+
+import "github.com/piwi3910/cnc-calculator/internal/model"
+
+const defaultMaxDepth = 50
+
+// Snapshot captures the parts and stocks state at a point in time.
+type Snapshot struct {
+	Parts  []model.Part
+	Stocks []model.StockSheet
+	Label  string // Human-readable description (e.g. "Add Part")
+}
+
+// History manages undo/redo stacks of project snapshots.
+type History struct {
+	undoStack []Snapshot
+	redoStack []Snapshot
+	maxDepth  int
+}
+
+// NewHistory creates a History with the default max depth of 50.
+func NewHistory() *History {
+	return &History{
+		maxDepth: defaultMaxDepth,
+	}
+}
+
+// Push saves a snapshot onto the undo stack and clears the redo stack.
+// This should be called before the modification is applied.
+func (h *History) Push(s Snapshot) {
+	h.undoStack = append(h.undoStack, s)
+	if len(h.undoStack) > h.maxDepth {
+		h.undoStack = h.undoStack[len(h.undoStack)-h.maxDepth:]
+	}
+	h.redoStack = nil
+}
+
+// Undo pops the most recent snapshot from the undo stack and pushes
+// the current state onto the redo stack. Returns the snapshot to restore
+// and true, or an empty snapshot and false if nothing to undo.
+func (h *History) Undo(current Snapshot) (Snapshot, bool) {
+	if len(h.undoStack) == 0 {
+		return Snapshot{}, false
+	}
+	// Pop from undo
+	last := h.undoStack[len(h.undoStack)-1]
+	h.undoStack = h.undoStack[:len(h.undoStack)-1]
+	// Push current state onto redo
+	h.redoStack = append(h.redoStack, current)
+	return last, true
+}
+
+// Redo pops the most recent snapshot from the redo stack and pushes
+// the current state onto the undo stack. Returns the snapshot to restore
+// and true, or an empty snapshot and false if nothing to redo.
+func (h *History) Redo(current Snapshot) (Snapshot, bool) {
+	if len(h.redoStack) == 0 {
+		return Snapshot{}, false
+	}
+	// Pop from redo
+	last := h.redoStack[len(h.redoStack)-1]
+	h.redoStack = h.redoStack[:len(h.redoStack)-1]
+	// Push current state onto undo
+	h.undoStack = append(h.undoStack, current)
+	return last, true
+}
+
+// CanUndo returns true if there is at least one snapshot to undo.
+func (h *History) CanUndo() bool {
+	return len(h.undoStack) > 0
+}
+
+// CanRedo returns true if there is at least one snapshot to redo.
+func (h *History) CanRedo() bool {
+	return len(h.redoStack) > 0
+}
+
+// Clear removes all undo and redo history.
+func (h *History) Clear() {
+	h.undoStack = nil
+	h.redoStack = nil
+}
+
+// copyParts returns a deep copy of a parts slice.
+func copyParts(parts []model.Part) []model.Part {
+	if parts == nil {
+		return nil
+	}
+	cp := make([]model.Part, len(parts))
+	copy(cp, parts)
+	return cp
+}
+
+// copyStocks returns a deep copy of a stocks slice.
+func copyStocks(stocks []model.StockSheet) []model.StockSheet {
+	if stocks == nil {
+		return nil
+	}
+	cp := make([]model.StockSheet, len(stocks))
+	for i, s := range stocks {
+		cp[i] = s
+		// Deep copy the Tabs.CustomZones slice
+		if s.Tabs.CustomZones != nil {
+			cp[i].Tabs.CustomZones = make([]model.TabZone, len(s.Tabs.CustomZones))
+			copy(cp[i].Tabs.CustomZones, s.Tabs.CustomZones)
+		}
+	}
+	return cp
+}
+
+// MakeSnapshot creates a snapshot from the current project state with a label.
+func MakeSnapshot(parts []model.Part, stocks []model.StockSheet, label string) Snapshot {
+	return Snapshot{
+		Parts:  copyParts(parts),
+		Stocks: copyStocks(stocks),
+		Label:  label,
+	}
+}

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -1,0 +1,273 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/piwi3910/cnc-calculator/internal/model"
+)
+
+func TestNewHistory(t *testing.T) {
+	h := NewHistory()
+	if h.maxDepth != defaultMaxDepth {
+		t.Errorf("expected maxDepth %d, got %d", defaultMaxDepth, h.maxDepth)
+	}
+	if h.CanUndo() {
+		t.Error("new history should not be undoable")
+	}
+	if h.CanRedo() {
+		t.Error("new history should not be redoable")
+	}
+}
+
+func TestPushAndUndo(t *testing.T) {
+	h := NewHistory()
+
+	// Push initial state (before adding a part)
+	snap0 := MakeSnapshot(nil, nil, "initial")
+	h.Push(snap0)
+
+	if !h.CanUndo() {
+		t.Fatal("should be able to undo after push")
+	}
+
+	// Current state has one part
+	currentParts := []model.Part{{ID: "p1", Label: "Part 1", Width: 100, Height: 50, Quantity: 1}}
+	current := MakeSnapshot(currentParts, nil, "current")
+
+	restored, ok := h.Undo(current)
+	if !ok {
+		t.Fatal("undo should succeed")
+	}
+	if len(restored.Parts) != 0 {
+		t.Errorf("expected 0 parts after undo, got %d", len(restored.Parts))
+	}
+	if restored.Label != "initial" {
+		t.Errorf("expected label 'initial', got %q", restored.Label)
+	}
+}
+
+func TestUndoRedo(t *testing.T) {
+	h := NewHistory()
+
+	// State 0: empty
+	snap0 := MakeSnapshot(nil, nil, "empty")
+	h.Push(snap0)
+
+	// State 1: one part
+	parts1 := []model.Part{{ID: "p1", Label: "Part 1", Width: 100, Height: 50, Quantity: 1}}
+	snap1 := MakeSnapshot(parts1, nil, "one part")
+	h.Push(snap1)
+
+	// Current state: two parts
+	parts2 := []model.Part{
+		{ID: "p1", Label: "Part 1", Width: 100, Height: 50, Quantity: 1},
+		{ID: "p2", Label: "Part 2", Width: 200, Height: 100, Quantity: 2},
+	}
+	current := MakeSnapshot(parts2, nil, "two parts")
+
+	// Undo to one part
+	restored, ok := h.Undo(current)
+	if !ok {
+		t.Fatal("first undo should succeed")
+	}
+	if len(restored.Parts) != 1 {
+		t.Errorf("expected 1 part, got %d", len(restored.Parts))
+	}
+
+	// Redo back to two parts
+	if !h.CanRedo() {
+		t.Fatal("should be able to redo")
+	}
+	redone, ok := h.Redo(restored)
+	if !ok {
+		t.Fatal("redo should succeed")
+	}
+	if len(redone.Parts) != 2 {
+		t.Errorf("expected 2 parts after redo, got %d", len(redone.Parts))
+	}
+}
+
+func TestPushClearsRedo(t *testing.T) {
+	h := NewHistory()
+
+	snap0 := MakeSnapshot(nil, nil, "empty")
+	h.Push(snap0)
+
+	parts1 := []model.Part{{ID: "p1", Label: "Part 1", Width: 100, Height: 50, Quantity: 1}}
+	current := MakeSnapshot(parts1, nil, "one part")
+
+	// Undo
+	_, ok := h.Undo(current)
+	if !ok {
+		t.Fatal("undo should succeed")
+	}
+	if !h.CanRedo() {
+		t.Fatal("should be able to redo after undo")
+	}
+
+	// Push new state - should clear redo
+	snap2 := MakeSnapshot(nil, nil, "new action")
+	h.Push(snap2)
+	if h.CanRedo() {
+		t.Error("redo stack should be cleared after push")
+	}
+}
+
+func TestMaxDepth(t *testing.T) {
+	h := &History{maxDepth: 3}
+
+	for i := 0; i < 5; i++ {
+		h.Push(MakeSnapshot(nil, nil, ""))
+	}
+
+	if len(h.undoStack) != 3 {
+		t.Errorf("expected undo stack length 3, got %d", len(h.undoStack))
+	}
+}
+
+func TestUndoEmpty(t *testing.T) {
+	h := NewHistory()
+	current := MakeSnapshot(nil, nil, "current")
+	_, ok := h.Undo(current)
+	if ok {
+		t.Error("undo on empty history should return false")
+	}
+}
+
+func TestRedoEmpty(t *testing.T) {
+	h := NewHistory()
+	current := MakeSnapshot(nil, nil, "current")
+	_, ok := h.Redo(current)
+	if ok {
+		t.Error("redo on empty history should return false")
+	}
+}
+
+func TestClear(t *testing.T) {
+	h := NewHistory()
+	h.Push(MakeSnapshot(nil, nil, "a"))
+	h.Push(MakeSnapshot(nil, nil, "b"))
+
+	// Create a redo entry
+	current := MakeSnapshot(nil, nil, "current")
+	h.Undo(current)
+
+	h.Clear()
+	if h.CanUndo() || h.CanRedo() {
+		t.Error("after clear, should not be able to undo or redo")
+	}
+}
+
+func TestDeepCopyParts(t *testing.T) {
+	original := []model.Part{{ID: "p1", Label: "Part 1", Width: 100, Height: 50, Quantity: 1}}
+	snap := MakeSnapshot(original, nil, "test")
+
+	// Mutate original
+	original[0].Label = "Modified"
+
+	if snap.Parts[0].Label != "Part 1" {
+		t.Error("snapshot should be independent of original slice")
+	}
+}
+
+func TestDeepCopyStocks(t *testing.T) {
+	original := []model.StockSheet{
+		{
+			ID: "s1", Label: "Sheet 1", Width: 2440, Height: 1220, Quantity: 1,
+			Tabs: model.StockTabConfig{
+				Enabled:     true,
+				CustomZones: []model.TabZone{{X: 10, Y: 10, Width: 50, Height: 50}},
+			},
+		},
+	}
+	snap := MakeSnapshot(nil, original, "test")
+
+	// Mutate original
+	original[0].Label = "Modified"
+	original[0].Tabs.CustomZones[0].X = 999
+
+	if snap.Stocks[0].Label != "Sheet 1" {
+		t.Error("snapshot stocks should be independent of original")
+	}
+	if snap.Stocks[0].Tabs.CustomZones[0].X != 10 {
+		t.Error("snapshot custom zones should be independent of original")
+	}
+}
+
+func TestCopyNilSlices(t *testing.T) {
+	snap := MakeSnapshot(nil, nil, "nil test")
+	if snap.Parts != nil {
+		t.Error("nil parts should stay nil")
+	}
+	if snap.Stocks != nil {
+		t.Error("nil stocks should stay nil")
+	}
+}
+
+func TestMultipleUndoRedo(t *testing.T) {
+	h := NewHistory()
+
+	// Build up 3 states: empty -> 1 part -> 2 parts -> 3 parts
+	h.Push(MakeSnapshot(nil, nil, "empty"))
+	h.Push(MakeSnapshot(
+		[]model.Part{{ID: "p1", Label: "P1", Width: 10, Height: 10, Quantity: 1}},
+		nil, "1 part",
+	))
+	h.Push(MakeSnapshot(
+		[]model.Part{
+			{ID: "p1", Label: "P1", Width: 10, Height: 10, Quantity: 1},
+			{ID: "p2", Label: "P2", Width: 20, Height: 20, Quantity: 1},
+		},
+		nil, "2 parts",
+	))
+
+	current := MakeSnapshot(
+		[]model.Part{
+			{ID: "p1", Label: "P1", Width: 10, Height: 10, Quantity: 1},
+			{ID: "p2", Label: "P2", Width: 20, Height: 20, Quantity: 1},
+			{ID: "p3", Label: "P3", Width: 30, Height: 30, Quantity: 1},
+		},
+		nil, "3 parts",
+	)
+
+	// Undo 3 times to get back to empty
+	s, ok := h.Undo(current)
+	if !ok || len(s.Parts) != 2 {
+		t.Fatalf("first undo: expected 2 parts, got %d", len(s.Parts))
+	}
+
+	s, ok = h.Undo(s)
+	if !ok || len(s.Parts) != 1 {
+		t.Fatalf("second undo: expected 1 part, got %d", len(s.Parts))
+	}
+
+	s, ok = h.Undo(s)
+	if !ok || len(s.Parts) != 0 {
+		t.Fatalf("third undo: expected 0 parts, got %d", len(s.Parts))
+	}
+
+	// No more undos
+	if h.CanUndo() {
+		t.Error("should not be able to undo further")
+	}
+
+	// Redo all the way forward
+	s, ok = h.Redo(s)
+	if !ok || len(s.Parts) != 1 {
+		t.Fatalf("first redo: expected 1 part, got %d", len(s.Parts))
+	}
+
+	s, ok = h.Redo(s)
+	if !ok || len(s.Parts) != 2 {
+		t.Fatalf("second redo: expected 2 parts, got %d", len(s.Parts))
+	}
+
+	s, ok = h.Redo(s)
+	if !ok || len(s.Parts) != 3 {
+		t.Fatalf("third redo: expected 3 parts, got %d", len(s.Parts))
+	}
+
+	if h.CanRedo() {
+		t.Error("should not be able to redo further")
+	}
+}


### PR DESCRIPTION
## Summary

- Add snapshot-based undo/redo history system (`internal/ui/history.go`) that deep-copies Parts and Stocks slices before each mutation, with a max depth of 50 operations
- Integrate undo/redo into all part and stock modification paths: add, edit, delete, clear all, new project, load project, and CSV/Excel import
- Add Undo/Redo menu items to the Edit menu and register Fyne keyboard shortcuts (Ctrl+Z / Cmd+Z for undo, Ctrl+Y / Cmd+Shift+Z for redo)
- Add comprehensive unit tests for the History manager covering push, undo, redo, max depth, clear, deep copy isolation, and multi-step undo/redo sequences

## Test plan

- [x] `go build ./...` compiles without errors
- [x] `go test ./...` passes all tests (12 test cases in `history_test.go`)
- [ ] Manual testing: add parts, undo with Ctrl+Z, redo with Ctrl+Y/Ctrl+Shift+Z
- [ ] Verify undo works for: add/edit/delete part, add/edit/delete stock, clear all, import

Resolves #8