### PR TITLE
[Feature] GCode preview with toolpath visualization

### DIFF
--- a/internal/gcode/parser.go
+++ b/internal/gcode/parser.go
@@ -1,0 +1,139 @@
+package gcode
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MoveType represents the type of CNC toolpath movement.
+type MoveType int
+
+const (
+	MoveRapid   MoveType = iota // G0: rapid positioning (no cutting)
+	MoveFeed                    // G1: linear feed (cutting move in XY plane)
+	MovePlunge                  // G1 with Z decreasing: plunging into material
+	MoveRetract                 // G0/G1 with Z increasing: retracting from material
+)
+
+// GCodeMove represents a single parsed movement from GCode.
+type GCodeMove struct {
+	Type     MoveType
+	FromX    float64
+	FromY    float64
+	FromZ    float64
+	ToX      float64
+	ToY      float64
+	ToZ      float64
+	FeedRate float64
+}
+
+// ParseGCode parses a GCode string into a slice of structured moves.
+// It tracks absolute position state and classifies each G0/G1 command
+// by its movement characteristics (rapid, feed, plunge, retract).
+func ParseGCode(code string) []GCodeMove {
+	var moves []GCodeMove
+
+	// Current machine state
+	curX, curY, curZ := 0.0, 0.0, 0.0
+	curFeed := 0.0
+
+	lines := strings.Split(code, "\n")
+
+	coordRe := regexp.MustCompile(`([XYZF])([-]?\d+\.?\d*)`)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Strip inline comments (semicolon or parenthetical)
+		if idx := strings.Index(line, ";"); idx >= 0 {
+			line = line[:idx]
+		}
+		if idx := strings.Index(line, "("); idx >= 0 {
+			if end := strings.Index(line, ")"); end > idx {
+				line = line[:idx] + line[end+1:]
+			}
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Determine command type
+		isRapid := false
+		isFeed := false
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(upper, "G0 ") || strings.HasPrefix(upper, "G00 ") || upper == "G0" || upper == "G00" {
+			isRapid = true
+		} else if strings.HasPrefix(upper, "G1 ") || strings.HasPrefix(upper, "G01 ") || upper == "G1" || upper == "G01" {
+			isFeed = true
+		}
+
+		if !isRapid && !isFeed {
+			continue
+		}
+
+		// Parse coordinates from this line
+		newX, newY, newZ, newFeed := curX, curY, curZ, curFeed
+		matches := coordRe.FindAllStringSubmatch(upper, -1)
+		for _, m := range matches {
+			val, err := strconv.ParseFloat(m[2], 64)
+			if err != nil {
+				continue
+			}
+			switch m[1] {
+			case "X":
+				newX = val
+			case "Y":
+				newY = val
+			case "Z":
+				newZ = val
+			case "F":
+				newFeed = val
+			}
+		}
+
+		// Classify the move
+		moveType := classifyMove(isRapid, curZ, newZ, curX, curY, newX, newY)
+
+		moves = append(moves, GCodeMove{
+			Type:     moveType,
+			FromX:    curX,
+			FromY:    curY,
+			FromZ:    curZ,
+			ToX:      newX,
+			ToY:      newY,
+			ToZ:      newZ,
+			FeedRate: newFeed,
+		})
+
+		curX, curY, curZ, curFeed = newX, newY, newZ, newFeed
+	}
+
+	return moves
+}
+
+// classifyMove determines the MoveType based on movement characteristics.
+func classifyMove(isRapid bool, fromZ, toZ, fromX, fromY, toX, toY float64) MoveType {
+	zDelta := toZ - fromZ
+	hasXY := fromX != toX || fromY != toY
+
+	switch {
+	case isRapid:
+		if zDelta > 0 {
+			return MoveRetract
+		}
+		return MoveRapid
+	case zDelta < -0.001 && !hasXY:
+		// Z going down (more negative) without XY movement = plunge
+		return MovePlunge
+	case zDelta > 0.001 && !hasXY:
+		// Z going up without XY movement = retract
+		return MoveRetract
+	default:
+		return MoveFeed
+	}
+}

--- a/internal/gcode/parser_test.go
+++ b/internal/gcode/parser_test.go
@@ -1,0 +1,247 @@
+package gcode
+
+import (
+	"testing"
+)
+
+func TestParseGCode_Empty(t *testing.T) {
+	moves := ParseGCode("")
+	if len(moves) != 0 {
+		t.Errorf("expected 0 moves for empty input, got %d", len(moves))
+	}
+}
+
+func TestParseGCode_CommentsOnly(t *testing.T) {
+	code := `; This is a comment
+; Another comment
+(parenthetical comment)
+`
+	moves := ParseGCode(code)
+	if len(moves) != 0 {
+		t.Errorf("expected 0 moves for comments-only input, got %d", len(moves))
+	}
+}
+
+func TestParseGCode_RapidMove(t *testing.T) {
+	code := "G0 X10.000 Y20.000\n"
+	moves := ParseGCode(code)
+	if len(moves) != 1 {
+		t.Fatalf("expected 1 move, got %d", len(moves))
+	}
+	m := moves[0]
+	if m.Type != MoveRapid {
+		t.Errorf("expected MoveRapid, got %d", m.Type)
+	}
+	if m.FromX != 0 || m.FromY != 0 {
+		t.Errorf("expected from (0,0), got (%.3f, %.3f)", m.FromX, m.FromY)
+	}
+	if m.ToX != 10 || m.ToY != 20 {
+		t.Errorf("expected to (10,20), got (%.3f, %.3f)", m.ToX, m.ToY)
+	}
+}
+
+func TestParseGCode_FeedMove(t *testing.T) {
+	code := "G0 X0.000 Y0.000\nG1 X100.000 Y0.000 F1500.0\n"
+	moves := ParseGCode(code)
+	if len(moves) != 2 {
+		t.Fatalf("expected 2 moves, got %d", len(moves))
+	}
+	m := moves[1]
+	if m.Type != MoveFeed {
+		t.Errorf("expected MoveFeed, got %d", m.Type)
+	}
+	if m.ToX != 100 || m.ToY != 0 {
+		t.Errorf("expected to (100,0), got (%.3f, %.3f)", m.ToX, m.ToY)
+	}
+	if m.FeedRate != 1500 {
+		t.Errorf("expected feed rate 1500, got %.1f", m.FeedRate)
+	}
+}
+
+func TestParseGCode_PlungeMove(t *testing.T) {
+	code := "G0 X10.000 Y10.000\nG0 Z5.000\nG1 Z-6.000 F500.0\n"
+	moves := ParseGCode(code)
+	if len(moves) != 3 {
+		t.Fatalf("expected 3 moves, got %d", len(moves))
+	}
+	m := moves[2]
+	if m.Type != MovePlunge {
+		t.Errorf("expected MovePlunge, got %d", m.Type)
+	}
+	if m.FromZ != 5 || m.ToZ != -6 {
+		t.Errorf("expected Z from 5 to -6, got %.3f to %.3f", m.FromZ, m.ToZ)
+	}
+}
+
+func TestParseGCode_RetractMove(t *testing.T) {
+	code := "G0 X10.000 Y10.000\nG1 Z-6.000 F500.0\nG0 Z5.000\n"
+	moves := ParseGCode(code)
+	if len(moves) != 3 {
+		t.Fatalf("expected 3 moves, got %d", len(moves))
+	}
+	m := moves[2]
+	if m.Type != MoveRetract {
+		t.Errorf("expected MoveRetract, got %d", m.Type)
+	}
+	if m.ToZ != 5 {
+		t.Errorf("expected retract to Z=5, got Z=%.3f", m.ToZ)
+	}
+}
+
+func TestParseGCode_InlineComment(t *testing.T) {
+	code := "G1 X50.000 Y50.000 F1500.0 ; cutting move\n"
+	moves := ParseGCode(code)
+	if len(moves) != 1 {
+		t.Fatalf("expected 1 move, got %d", len(moves))
+	}
+	if moves[0].ToX != 50 || moves[0].ToY != 50 {
+		t.Errorf("expected to (50,50), got (%.3f, %.3f)", moves[0].ToX, moves[0].ToY)
+	}
+}
+
+func TestParseGCode_NonMovementLines(t *testing.T) {
+	code := `G90
+G21
+G17
+M3 S18000
+G0 X0.000 Y0.000
+G0 Z5.000
+`
+	moves := ParseGCode(code)
+	if len(moves) != 2 {
+		t.Errorf("expected 2 moves (only G0 lines), got %d", len(moves))
+	}
+}
+
+func TestParseGCode_StateTracking(t *testing.T) {
+	code := `G0 X10.000 Y20.000
+G0 Z5.000
+G1 Z-6.000 F500.0
+G1 X100.000 Y20.000 F1500.0
+G1 X100.000 Y80.000
+G0 Z5.000
+`
+	moves := ParseGCode(code)
+	if len(moves) != 6 {
+		t.Fatalf("expected 6 moves, got %d", len(moves))
+	}
+
+	// Verify position state is tracked across moves
+	// Move 3 (index 2): plunge at X=10, Y=20
+	if moves[2].FromX != 10 || moves[2].FromY != 20 {
+		t.Errorf("move 2: expected from (10,20), got (%.3f, %.3f)", moves[2].FromX, moves[2].FromY)
+	}
+	// Move 4 (index 3): feed from (10,20) to (100,20)
+	if moves[3].FromX != 10 || moves[3].ToX != 100 {
+		t.Errorf("move 3: expected X from 10 to 100, got %.3f to %.3f", moves[3].FromX, moves[3].ToX)
+	}
+	// Move 5 (index 4): feed from (100,20) to (100,80)
+	if moves[4].FromX != 100 || moves[4].FromY != 20 || moves[4].ToY != 80 {
+		t.Errorf("move 4: expected from (100,20) to (100,80), got (%.3f,%.3f) to (%.3f,%.3f)",
+			moves[4].FromX, moves[4].FromY, moves[4].ToX, moves[4].ToY)
+	}
+}
+
+func TestParseGCode_FeedRateSticky(t *testing.T) {
+	code := `G1 X10.000 Y10.000 F1500.0
+G1 X20.000 Y20.000
+`
+	moves := ParseGCode(code)
+	if len(moves) != 2 {
+		t.Fatalf("expected 2 moves, got %d", len(moves))
+	}
+	// Feed rate should persist from previous command
+	if moves[1].FeedRate != 1500 {
+		t.Errorf("expected sticky feed rate 1500, got %.1f", moves[1].FeedRate)
+	}
+}
+
+func TestParseGCode_FullCutSequence(t *testing.T) {
+	// Simulate a realistic single-part GCode sequence
+	code := `; CNCCalculator GCode - Sheet 1
+G90
+G21
+G17
+M3 S18000
+G0 X0.000 Y0.000
+G0 Z5.000
+
+; --- Part 1: Shelf (600.0 x 300.0) ---
+; Pass 1/3, depth=6.00mm
+G0 X-3.000 Y-3.000
+G1 Z-6.000 F500.0 ; Plunge
+G1 X603.000 Y-3.000 F1500.0
+G1 X603.000 Y303.000
+G1 X-3.000 Y303.000
+G1 X-3.000 Y-3.000
+G0 Z5.000
+
+; === Job complete ===
+G0 Z5.000
+G0 X0 Y0
+M5
+M2
+`
+	moves := ParseGCode(code)
+
+	// Count move types
+	counts := map[MoveType]int{}
+	for _, m := range moves {
+		counts[m.Type]++
+	}
+
+	if counts[MoveRapid] < 2 {
+		t.Errorf("expected at least 2 rapid moves, got %d", counts[MoveRapid])
+	}
+	if counts[MoveFeed] < 4 {
+		t.Errorf("expected at least 4 feed moves (rectangle perimeter), got %d", counts[MoveFeed])
+	}
+	if counts[MovePlunge] < 1 {
+		t.Errorf("expected at least 1 plunge move, got %d", counts[MovePlunge])
+	}
+	if counts[MoveRetract] < 1 {
+		t.Errorf("expected at least 1 retract move, got %d", counts[MoveRetract])
+	}
+}
+
+func TestClassifyMove(t *testing.T) {
+	tests := []struct {
+		name    string
+		isRapid bool
+		fromZ   float64
+		toZ     float64
+		fromX   float64
+		fromY   float64
+		toX     float64
+		toY     float64
+		want    MoveType
+	}{
+		{"rapid XY", true, 5, 5, 0, 0, 10, 20, MoveRapid},
+		{"rapid retract", true, -6, 5, 10, 20, 10, 20, MoveRetract},
+		{"rapid with Z up", true, 0, 5, 0, 0, 0, 0, MoveRetract},
+		{"feed XY", false, -6, -6, 0, 0, 100, 0, MoveFeed},
+		{"plunge", false, 5, -6, 10, 20, 10, 20, MovePlunge},
+		{"retract feed", false, -6, 0, 10, 20, 10, 20, MoveRetract},
+		{"feed with slight Z", false, -6, -6.0001, 0, 0, 100, 0, MoveFeed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyMove(tt.isRapid, tt.fromZ, tt.toZ, tt.fromX, tt.fromY, tt.toX, tt.toY)
+			if got != tt.want {
+				t.Errorf("classifyMove() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGCode_NegativeCoordinates(t *testing.T) {
+	code := "G0 X-3.000 Y-3.000\n"
+	moves := ParseGCode(code)
+	if len(moves) != 1 {
+		t.Fatalf("expected 1 move, got %d", len(moves))
+	}
+	if moves[0].ToX != -3 || moves[0].ToY != -3 {
+		t.Errorf("expected to (-3,-3), got (%.3f, %.3f)", moves[0].ToX, moves[0].ToY)
+	}
+}

--- a/internal/ui/widgets/gcode_preview.go
+++ b/internal/ui/widgets/gcode_preview.go
@@ -1,0 +1,343 @@
+package widgets
+
+import (
+	"image/color"
+	"math"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/piwi3910/SlabCut/internal/gcode"
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// Toolpath colors for different move types.
+var (
+	colorRapid   = color.NRGBA{R: 255, G: 60, B: 60, A: 200}   // Red for rapid moves
+	colorFeed    = color.NRGBA{R: 30, G: 120, B: 255, A: 230}  // Blue for cutting moves
+	colorPlunge  = color.NRGBA{R: 50, G: 200, B: 50, A: 220}   // Green for plunge
+	colorRetract = color.NRGBA{R: 180, G: 180, B: 0, A: 180}   // Yellow for retract
+	colorSheet   = color.NRGBA{R: 230, G: 210, B: 175, A: 255} // Light wood for stock
+	colorPart    = color.NRGBA{R: 200, G: 220, B: 255, A: 120} // Light blue for part outlines
+	colorTab     = color.NRGBA{R: 255, G: 165, B: 0, A: 220}   // Orange for tab markers
+)
+
+// GCodePreview is a custom Fyne widget that renders a visual preview
+// of GCode toolpath movements overlaid on a stock sheet with part outlines.
+type GCodePreview struct {
+	widget.BaseWidget
+	moves      []gcode.GCodeMove
+	placements []model.Placement
+	settings   model.CutSettings
+	sheetW     float64
+	sheetH     float64
+	maxWidth   float32
+	maxHeight  float32
+}
+
+// NewGCodePreview creates a new GCode preview widget.
+func NewGCodePreview(moves []gcode.GCodeMove, placements []model.Placement, settings model.CutSettings, sheetW, sheetH float64, maxW, maxH float32) *GCodePreview {
+	gp := &GCodePreview{
+		moves:      moves,
+		placements: placements,
+		settings:   settings,
+		sheetW:     sheetW,
+		sheetH:     sheetH,
+		maxWidth:   maxW,
+		maxHeight:  maxH,
+	}
+	gp.ExtendBaseWidget(gp)
+	return gp
+}
+
+// CreateRenderer implements fyne.Widget.
+func (gp *GCodePreview) CreateRenderer() fyne.WidgetRenderer {
+	return newGCodePreviewRenderer(gp)
+}
+
+type gcodePreviewRenderer struct {
+	gp      *GCodePreview
+	objects []fyne.CanvasObject
+}
+
+func newGCodePreviewRenderer(gp *GCodePreview) *gcodePreviewRenderer {
+	r := &gcodePreviewRenderer{gp: gp}
+	r.rebuild()
+	return r
+}
+
+func (r *gcodePreviewRenderer) rebuild() {
+	r.objects = nil
+
+	gp := r.gp
+	stockW := float32(gp.sheetW)
+	stockH := float32(gp.sheetH)
+
+	if stockW <= 0 || stockH <= 0 {
+		return
+	}
+
+	// Calculate scale to fit within max bounds, with margin for tool offset
+	margin := float32(gp.settings.ToolDiameter) + 10
+	scaleX := (gp.maxWidth - margin*2) / stockW
+	scaleY := (gp.maxHeight - margin*2) / stockH
+	scale := scaleX
+	if scaleY < scale {
+		scale = scaleY
+	}
+	if scale <= 0 {
+		scale = 1
+	}
+
+	offsetX := margin
+	offsetY := margin
+
+	canvasW := stockW * scale
+	canvasH := stockH * scale
+
+	// Stock sheet background
+	bg := canvas.NewRectangle(colorSheet)
+	bg.Resize(fyne.NewSize(canvasW, canvasH))
+	bg.Move(fyne.NewPos(offsetX, offsetY))
+	r.objects = append(r.objects, bg)
+
+	// Stock border
+	border := canvas.NewRectangle(color.Transparent)
+	border.StrokeColor = color.NRGBA{R: 80, G: 80, B: 80, A: 255}
+	border.StrokeWidth = 2
+	border.Resize(fyne.NewSize(canvasW, canvasH))
+	border.Move(fyne.NewPos(offsetX, offsetY))
+	r.objects = append(r.objects, border)
+
+	// Draw part outlines
+	for _, p := range gp.placements {
+		pw := float32(p.PlacedWidth()) * scale
+		ph := float32(p.PlacedHeight()) * scale
+		px := float32(p.X)*scale + offsetX
+		py := float32(p.Y)*scale + offsetY
+
+		partRect := canvas.NewRectangle(colorPart)
+		partRect.Resize(fyne.NewSize(pw, ph))
+		partRect.Move(fyne.NewPos(px, py))
+		r.objects = append(r.objects, partRect)
+
+		partBorder := canvas.NewRectangle(color.Transparent)
+		partBorder.StrokeColor = color.NRGBA{R: 100, G: 130, B: 180, A: 200}
+		partBorder.StrokeWidth = 1.5
+		partBorder.Resize(fyne.NewSize(pw, ph))
+		partBorder.Move(fyne.NewPos(px, py))
+		r.objects = append(r.objects, partBorder)
+
+		// Part label
+		if pw > 40 && ph > 18 {
+			label := canvas.NewText(p.Part.Label, color.NRGBA{R: 50, G: 70, B: 120, A: 200})
+			label.TextSize = 10
+			label.Move(fyne.NewPos(px+3, py+2))
+			r.objects = append(r.objects, label)
+		}
+	}
+
+	// Draw tab markers if tabs are configured
+	if gp.settings.PartTabsPerSide > 0 {
+		r.drawTabMarkers(scale, offsetX, offsetY)
+	}
+
+	// Draw toolpath lines
+	for _, m := range gp.moves {
+		fromX := float32(m.FromX)*scale + offsetX
+		fromY := float32(m.FromY)*scale + offsetY
+		toX := float32(m.ToX)*scale + offsetX
+		toY := float32(m.ToY)*scale + offsetY
+
+		// Skip zero-length moves and pure Z-only moves (plunge/retract shown as markers)
+		dx := m.ToX - m.FromX
+		dy := m.ToY - m.FromY
+		xyDist := math.Sqrt(dx*dx + dy*dy)
+
+		switch m.Type {
+		case gcode.MoveRapid:
+			if xyDist < 0.01 {
+				continue
+			}
+			line := canvas.NewLine(colorRapid)
+			line.StrokeWidth = 1
+			line.Position1 = fyne.NewPos(fromX, fromY)
+			line.Position2 = fyne.NewPos(toX, toY)
+			r.objects = append(r.objects, line)
+
+			// Draw dashes along rapid moves for visual distinction
+			r.drawDashedOverlay(fromX, fromY, toX, toY, colorRapid)
+
+		case gcode.MoveFeed:
+			if xyDist < 0.01 {
+				continue
+			}
+			line := canvas.NewLine(colorFeed)
+			line.StrokeWidth = 2
+			line.Position1 = fyne.NewPos(fromX, fromY)
+			line.Position2 = fyne.NewPos(toX, toY)
+			r.objects = append(r.objects, line)
+
+		case gcode.MovePlunge:
+			// Draw a small downward arrow marker at plunge position
+			marker := canvas.NewCircle(colorPlunge)
+			markerSize := float32(4)
+			marker.Resize(fyne.NewSize(markerSize, markerSize))
+			marker.Move(fyne.NewPos(fromX-markerSize/2, fromY-markerSize/2))
+			r.objects = append(r.objects, marker)
+
+		case gcode.MoveRetract:
+			if xyDist < 0.01 {
+				// Pure Z retract: show small upward marker
+				marker := canvas.NewCircle(colorRetract)
+				markerSize := float32(3)
+				marker.Resize(fyne.NewSize(markerSize, markerSize))
+				marker.Move(fyne.NewPos(fromX-markerSize/2, fromY-markerSize/2))
+				r.objects = append(r.objects, marker)
+			} else {
+				line := canvas.NewLine(colorRetract)
+				line.StrokeWidth = 1
+				line.Position1 = fyne.NewPos(fromX, fromY)
+				line.Position2 = fyne.NewPos(toX, toY)
+				r.objects = append(r.objects, line)
+			}
+		}
+	}
+}
+
+// drawDashedOverlay adds alternating gaps along a rapid move line for dashed appearance.
+func (r *gcodePreviewRenderer) drawDashedOverlay(x1, y1, x2, y2 float32, col color.NRGBA) {
+	dx := x2 - x1
+	dy := y2 - y1
+	length := float32(math.Sqrt(float64(dx*dx + dy*dy)))
+	if length < 8 {
+		return
+	}
+
+	dashLen := float32(6)
+	gapLen := float32(4)
+	nx := dx / length
+	ny := dy / length
+
+	// Overlay background-colored segments for gaps
+	bgColor := colorSheet
+	cursor := dashLen
+	for cursor+gapLen < length {
+		gx1 := x1 + nx*cursor
+		gy1 := y1 + ny*cursor
+		gx2 := x1 + nx*(cursor+gapLen)
+		gy2 := y1 + ny*(cursor+gapLen)
+
+		gap := canvas.NewLine(bgColor)
+		gap.StrokeWidth = 2.5
+		gap.Position1 = fyne.NewPos(gx1, gy1)
+		gap.Position2 = fyne.NewPos(gx2, gy2)
+		r.objects = append(r.objects, gap)
+
+		cursor += dashLen + gapLen
+	}
+	_ = col // color parameter reserved for potential future use
+}
+
+// drawTabMarkers draws small orange rectangles where holding tabs are positioned.
+func (r *gcodePreviewRenderer) drawTabMarkers(scale, offsetX, offsetY float32) {
+	settings := r.gp.settings
+	tabW := float32(settings.PartTabWidth) * scale
+	tabMarkerH := float32(3) // Fixed visual height for tab markers
+
+	for _, p := range r.gp.placements {
+		toolR := settings.ToolDiameter / 2.0
+		pw := p.PlacedWidth() + settings.ToolDiameter
+		ph := p.PlacedHeight() + settings.ToolDiameter
+		x0 := float32(p.X-toolR)*scale + offsetX
+		y0 := float32(p.Y-toolR)*scale + offsetY
+
+		for side := 0; side < 4; side++ {
+			var sideLen float64
+			if side == 0 || side == 2 {
+				sideLen = pw
+			} else {
+				sideLen = ph
+			}
+			spacing := sideLen / float64(settings.PartTabsPerSide+1)
+
+			for t := 1; t <= settings.PartTabsPerSide; t++ {
+				pos := float32(spacing*float64(t)) * scale
+				var tx, ty, tw, th float32
+
+				switch side {
+				case 0: // bottom: along X at y0
+					tx = x0 + pos - tabW/2
+					ty = y0 - tabMarkerH/2
+					tw = tabW
+					th = tabMarkerH
+				case 1: // right: along Y at x0+pw*scale
+					tx = x0 + float32(pw)*scale - tabMarkerH/2
+					ty = y0 + pos - tabW/2
+					tw = tabMarkerH
+					th = tabW
+				case 2: // top: along X at y0+ph*scale
+					tx = x0 + float32(pw)*scale - pos - tabW/2
+					ty = y0 + float32(ph)*scale - tabMarkerH/2
+					tw = tabW
+					th = tabMarkerH
+				case 3: // left: along Y at x0
+					tx = x0 - tabMarkerH/2
+					ty = y0 + float32(ph)*scale - pos - tabW/2
+					tw = tabMarkerH
+					th = tabW
+				}
+
+				tabRect := canvas.NewRectangle(colorTab)
+				tabRect.Resize(fyne.NewSize(tw, th))
+				tabRect.Move(fyne.NewPos(tx, ty))
+				r.objects = append(r.objects, tabRect)
+			}
+		}
+	}
+}
+
+func (r *gcodePreviewRenderer) Layout(size fyne.Size)        {}
+func (r *gcodePreviewRenderer) Refresh()                     { r.rebuild() }
+func (r *gcodePreviewRenderer) Destroy()                     {}
+func (r *gcodePreviewRenderer) Objects() []fyne.CanvasObject { return r.objects }
+
+func (r *gcodePreviewRenderer) MinSize() fyne.Size {
+	gp := r.gp
+	stockW := float32(gp.sheetW)
+	stockH := float32(gp.sheetH)
+	if stockW <= 0 || stockH <= 0 {
+		return fyne.NewSize(100, 100)
+	}
+
+	margin := float32(gp.settings.ToolDiameter) + 10
+	scaleX := (gp.maxWidth - margin*2) / stockW
+	scaleY := (gp.maxHeight - margin*2) / stockH
+	scale := scaleX
+	if scaleY < scale {
+		scale = scaleY
+	}
+	if scale <= 0 {
+		scale = 1
+	}
+
+	return fyne.NewSize(stockW*scale+margin*2, stockH*scale+margin*2)
+}
+
+// RenderGCodePreview creates a complete preview panel for a sheet's GCode output,
+// including the toolpath visualization and a color legend.
+func RenderGCodePreview(sheet model.SheetResult, settings model.CutSettings, gcodeStr string) fyne.CanvasObject {
+	moves := gcode.ParseGCode(gcodeStr)
+
+	preview := NewGCodePreview(
+		moves,
+		sheet.Placements,
+		settings,
+		sheet.Stock.Width,
+		sheet.Stock.Height,
+		700, 450,
+	)
+
+	return preview
+}


### PR DESCRIPTION
## Summary

- **GCode parser** (`internal/gcode/parser.go`): Parses GCode strings into structured `GCodeMove` data, tracking machine position state and classifying each G0/G1 command as rapid, feed, plunge, or retract
- **Preview widget** (`internal/ui/widgets/gcode_preview.go`): Custom Fyne widget that renders toolpath visualization overlaid on the stock sheet with part outlines, using distinct colors for each move type (red dashed = rapid, blue solid = cutting, green dots = plunge, yellow dots = retract, orange = tab positions)
- **UI integration** (`internal/ui/app.go`): "Preview GCode" button added to both the results panel toolbar and the File menu; opens a scrollable dialog showing per-sheet toolpath previews with a color legend

## Test plan

- [x] 13 unit tests in `internal/gcode/parser_test.go` covering all move types, state tracking, comment handling, negative coordinates, and full cut sequences
- [x] `go build ./internal/...` compiles without errors
- [x] `go vet ./...` passes with no warnings
- [x] `go test ./...` all tests pass
- [ ] Manual testing: run the app, add parts and stock, optimize, then click "Preview GCode" to verify the toolpath visualization renders correctly

Resolves #4