### PR TITLE
[Feature] Admin menu for inventory management

### DIFF
--- a/internal/model/appconfig.go
+++ b/internal/model/appconfig.go
@@ -1,0 +1,57 @@
+package model
+
+// AppConfig holds application-wide preferences and default settings.
+type AppConfig struct {
+	// Default CNC settings applied to new projects
+	DefaultKerfWidth    float64 `json:"default_kerf_width"`
+	DefaultEdgeTrim     float64 `json:"default_edge_trim"`
+	DefaultToolDiameter float64 `json:"default_tool_diameter"`
+	DefaultFeedRate     float64 `json:"default_feed_rate"`
+	DefaultPlungeRate   float64 `json:"default_plunge_rate"`
+	DefaultSpindleSpeed int     `json:"default_spindle_speed"`
+	DefaultSafeZ        float64 `json:"default_safe_z"`
+	DefaultCutDepth     float64 `json:"default_cut_depth"`
+	DefaultPassDepth    float64 `json:"default_pass_depth"`
+	DefaultGCodeProfile string  `json:"default_gcode_profile"`
+
+	// Application preferences
+	AutoSaveInterval int      `json:"auto_save_interval"` // minutes, 0 = disabled
+	RecentProjects   []string `json:"recent_projects"`
+	Theme            string   `json:"theme"` // "light", "dark", "system"
+}
+
+// DefaultAppConfig returns an AppConfig populated with sensible defaults
+// matching the values from DefaultSettings().
+func DefaultAppConfig() AppConfig {
+	defaults := DefaultSettings()
+	return AppConfig{
+		DefaultKerfWidth:    defaults.KerfWidth,
+		DefaultEdgeTrim:     defaults.EdgeTrim,
+		DefaultToolDiameter: defaults.ToolDiameter,
+		DefaultFeedRate:     defaults.FeedRate,
+		DefaultPlungeRate:   defaults.PlungeRate,
+		DefaultSpindleSpeed: defaults.SpindleSpeed,
+		DefaultSafeZ:        defaults.SafeZ,
+		DefaultCutDepth:     defaults.CutDepth,
+		DefaultPassDepth:    defaults.PassDepth,
+		DefaultGCodeProfile: defaults.GCodeProfile,
+		AutoSaveInterval:    0,
+		RecentProjects:      []string{},
+		Theme:               "system",
+	}
+}
+
+// ApplyToSettings copies the default values from AppConfig into a CutSettings struct.
+// This is used when creating a new project so it inherits the user's saved defaults.
+func (c AppConfig) ApplyToSettings(s *CutSettings) {
+	s.KerfWidth = c.DefaultKerfWidth
+	s.EdgeTrim = c.DefaultEdgeTrim
+	s.ToolDiameter = c.DefaultToolDiameter
+	s.FeedRate = c.DefaultFeedRate
+	s.PlungeRate = c.DefaultPlungeRate
+	s.SpindleSpeed = c.DefaultSpindleSpeed
+	s.SafeZ = c.DefaultSafeZ
+	s.CutDepth = c.DefaultCutDepth
+	s.PassDepth = c.DefaultPassDepth
+	s.GCodeProfile = c.DefaultGCodeProfile
+}

--- a/internal/model/appconfig_test.go
+++ b/internal/model/appconfig_test.go
@@ -1,0 +1,47 @@
+package model
+
+import "testing"
+
+func TestDefaultAppConfigMatchesDefaultSettings(t *testing.T) {
+	cfg := DefaultAppConfig()
+	defaults := DefaultSettings()
+
+	if cfg.DefaultKerfWidth != defaults.KerfWidth {
+		t.Errorf("KerfWidth mismatch: config=%f settings=%f", cfg.DefaultKerfWidth, defaults.KerfWidth)
+	}
+	if cfg.DefaultToolDiameter != defaults.ToolDiameter {
+		t.Errorf("ToolDiameter mismatch: config=%f settings=%f", cfg.DefaultToolDiameter, defaults.ToolDiameter)
+	}
+	if cfg.DefaultFeedRate != defaults.FeedRate {
+		t.Errorf("FeedRate mismatch: config=%f settings=%f", cfg.DefaultFeedRate, defaults.FeedRate)
+	}
+	if cfg.DefaultGCodeProfile != defaults.GCodeProfile {
+		t.Errorf("GCodeProfile mismatch: config=%s settings=%s", cfg.DefaultGCodeProfile, defaults.GCodeProfile)
+	}
+	if cfg.Theme != "system" {
+		t.Errorf("expected default theme=system, got %s", cfg.Theme)
+	}
+	if cfg.RecentProjects == nil {
+		t.Error("RecentProjects should not be nil")
+	}
+}
+
+func TestApplyToSettings(t *testing.T) {
+	cfg := DefaultAppConfig()
+	cfg.DefaultKerfWidth = 5.0
+	cfg.DefaultFeedRate = 3000.0
+	cfg.DefaultGCodeProfile = "Grbl"
+
+	s := DefaultSettings()
+	cfg.ApplyToSettings(&s)
+
+	if s.KerfWidth != 5.0 {
+		t.Errorf("expected KerfWidth=5.0, got %f", s.KerfWidth)
+	}
+	if s.FeedRate != 3000.0 {
+		t.Errorf("expected FeedRate=3000.0, got %f", s.FeedRate)
+	}
+	if s.GCodeProfile != "Grbl" {
+		t.Errorf("expected GCodeProfile=Grbl, got %s", s.GCodeProfile)
+	}
+}

--- a/internal/project/appconfig.go
+++ b/internal/project/appconfig.go
@@ -1,0 +1,59 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// DefaultConfigDir returns the default directory for application configuration.
+// On all platforms this is ~/.slabcut/
+func DefaultConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".slabcut")
+}
+
+// DefaultConfigPath returns the default path for the application config file.
+func DefaultConfigPath() string {
+	return filepath.Join(DefaultConfigDir(), "config.json")
+}
+
+// SaveAppConfig persists an AppConfig to the given path as JSON.
+// It creates any missing parent directories automatically.
+func SaveAppConfig(path string, config model.AppConfig) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadAppConfig reads an AppConfig from the given path.
+// If the file does not exist, it returns DefaultAppConfig with no error.
+func LoadAppConfig(path string) (model.AppConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return model.DefaultAppConfig(), nil
+		}
+		return model.AppConfig{}, err
+	}
+	var config model.AppConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return model.AppConfig{}, err
+	}
+	// Ensure RecentProjects is never nil
+	if config.RecentProjects == nil {
+		config.RecentProjects = []string{}
+	}
+	return config, nil
+}

--- a/internal/project/appconfig_test.go
+++ b/internal/project/appconfig_test.go
@@ -1,0 +1,106 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+func TestSaveAndLoadAppConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := model.DefaultAppConfig()
+	cfg.DefaultKerfWidth = 4.0
+	cfg.Theme = "dark"
+	cfg.AutoSaveInterval = 5
+	cfg.RecentProjects = []string{"/tmp/proj1.cnccalc", "/tmp/proj2.cnccalc"}
+
+	if err := SaveAppConfig(path, cfg); err != nil {
+		t.Fatalf("SaveAppConfig failed: %v", err)
+	}
+
+	loaded, err := LoadAppConfig(path)
+	if err != nil {
+		t.Fatalf("LoadAppConfig failed: %v", err)
+	}
+
+	if loaded.DefaultKerfWidth != 4.0 {
+		t.Errorf("expected DefaultKerfWidth=4.0, got %f", loaded.DefaultKerfWidth)
+	}
+	if loaded.Theme != "dark" {
+		t.Errorf("expected Theme=dark, got %s", loaded.Theme)
+	}
+	if loaded.AutoSaveInterval != 5 {
+		t.Errorf("expected AutoSaveInterval=5, got %d", loaded.AutoSaveInterval)
+	}
+	if len(loaded.RecentProjects) != 2 {
+		t.Errorf("expected 2 recent projects, got %d", len(loaded.RecentProjects))
+	}
+}
+
+func TestLoadAppConfigMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent", "config.json")
+
+	cfg, err := LoadAppConfig(path)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+
+	defaults := model.DefaultAppConfig()
+	if cfg.DefaultKerfWidth != defaults.DefaultKerfWidth {
+		t.Errorf("expected default kerf width %f, got %f", defaults.DefaultKerfWidth, cfg.DefaultKerfWidth)
+	}
+	if cfg.Theme != "system" {
+		t.Errorf("expected theme=system, got %s", cfg.Theme)
+	}
+}
+
+func TestLoadAppConfigInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if err := os.WriteFile(path, []byte("not valid json{{{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadAppConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestSaveAppConfigCreatesDirectories(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "dir", "config.json")
+
+	cfg := model.DefaultAppConfig()
+	if err := SaveAppConfig(path, cfg); err != nil {
+		t.Fatalf("SaveAppConfig should create parent dirs: %v", err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("config file was not created")
+	}
+}
+
+func TestLoadAppConfigNilRecentProjects(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Write config with null recent_projects
+	data := []byte(`{"default_kerf_width":3.2,"theme":"light","recent_projects":null}`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadAppConfig(path)
+	if err != nil {
+		t.Fatalf("LoadAppConfig failed: %v", err)
+	}
+	if cfg.RecentProjects == nil {
+		t.Error("RecentProjects should not be nil after loading")
+	}
+}

--- a/internal/project/backup.go
+++ b/internal/project/backup.go
@@ -1,0 +1,63 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// BackupData is the top-level structure for import/export of all application data.
+type BackupData struct {
+	Version   string          `json:"version"`
+	CreatedAt string          `json:"created_at"`
+	Config    model.AppConfig `json:"config"`
+}
+
+// ExportAllData exports all application data (config and future inventory data)
+// to a single JSON file at the specified path.
+func ExportAllData(exportPath string, config model.AppConfig) error {
+	backup := BackupData{
+		Version:   "1.0.0",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Config:    config,
+	}
+	data, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal backup data: %w", err)
+	}
+
+	dir := filepath.Dir(exportPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create export directory: %w", err)
+	}
+
+	if err := os.WriteFile(exportPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write backup file: %w", err)
+	}
+	return nil
+}
+
+// ImportAllData reads a backup JSON file and returns the contained data.
+// The caller is responsible for applying the imported config.
+func ImportAllData(importPath string) (BackupData, error) {
+	data, err := os.ReadFile(importPath)
+	if err != nil {
+		return BackupData{}, fmt.Errorf("failed to read backup file: %w", err)
+	}
+	var backup BackupData
+	if err := json.Unmarshal(data, &backup); err != nil {
+		return BackupData{}, fmt.Errorf("failed to parse backup file: %w", err)
+	}
+	if backup.Version == "" {
+		return BackupData{}, fmt.Errorf("invalid backup file: missing version field")
+	}
+	// Ensure RecentProjects is never nil
+	if backup.Config.RecentProjects == nil {
+		backup.Config.RecentProjects = []string{}
+	}
+	return backup, nil
+}

--- a/internal/project/backup_test.go
+++ b/internal/project/backup_test.go
@@ -1,0 +1,105 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+func TestExportAndImportAllData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "backup.json")
+
+	cfg := model.DefaultAppConfig()
+	cfg.DefaultFeedRate = 2000.0
+	cfg.Theme = "dark"
+
+	if err := ExportAllData(path, cfg); err != nil {
+		t.Fatalf("ExportAllData failed: %v", err)
+	}
+
+	backup, err := ImportAllData(path)
+	if err != nil {
+		t.Fatalf("ImportAllData failed: %v", err)
+	}
+
+	if backup.Version != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %s", backup.Version)
+	}
+	if backup.CreatedAt == "" {
+		t.Error("expected non-empty CreatedAt")
+	}
+	if backup.Config.DefaultFeedRate != 2000.0 {
+		t.Errorf("expected DefaultFeedRate=2000.0, got %f", backup.Config.DefaultFeedRate)
+	}
+	if backup.Config.Theme != "dark" {
+		t.Errorf("expected Theme=dark, got %s", backup.Config.Theme)
+	}
+}
+
+func TestImportAllDataMissingFile(t *testing.T) {
+	_, err := ImportAllData(filepath.Join(t.TempDir(), "nope.json"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestImportAllDataInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("{not json}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ImportAllData(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestImportAllDataMissingVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "noversion.json")
+	data := []byte(`{"config":{"theme":"dark"}}`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ImportAllData(path)
+	if err == nil {
+		t.Fatal("expected error for missing version")
+	}
+}
+
+func TestExportAllDataCreatesDirectories(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deep", "nested", "backup.json")
+
+	cfg := model.DefaultAppConfig()
+	if err := ExportAllData(path, cfg); err != nil {
+		t.Fatalf("ExportAllData should create parent dirs: %v", err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("backup file was not created")
+	}
+}
+
+func TestImportAllDataNilRecentProjects(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "backup.json")
+	data := []byte(`{"version":"1.0.0","created_at":"2025-01-01T00:00:00Z","config":{"recent_projects":null}}`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	backup, err := ImportAllData(path)
+	if err != nil {
+		t.Fatalf("ImportAllData failed: %v", err)
+	}
+	if backup.Config.RecentProjects == nil {
+		t.Error("RecentProjects should not be nil after import")
+	}
+}

--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -1,0 +1,161 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+	"github.com/piwi3910/SlabCut/internal/project"
+)
+
+// showSettingsDialog displays the application settings editor.
+func (a *App) showSettingsDialog() {
+	cfg := a.config
+
+	// Helper to create a float entry bound to a pointer
+	floatEntry := func(val *float64) *widget.Entry {
+		e := widget.NewEntry()
+		e.SetText(fmt.Sprintf("%.1f", *val))
+		e.OnChanged = func(text string) {
+			if v, err := strconv.ParseFloat(text, 64); err == nil {
+				*val = v
+			}
+		}
+		return e
+	}
+
+	intEntry := func(val *int) *widget.Entry {
+		e := widget.NewEntry()
+		e.SetText(fmt.Sprintf("%d", *val))
+		e.OnChanged = func(text string) {
+			if v, err := strconv.Atoi(text); err == nil {
+				*val = v
+			}
+		}
+		return e
+	}
+
+	// GCode profile selector
+	profileNames := model.GetProfileNames()
+	profileSelect := widget.NewSelect(profileNames, func(selected string) {
+		cfg.DefaultGCodeProfile = selected
+	})
+	profileSelect.SetSelected(cfg.DefaultGCodeProfile)
+
+	// Theme selector
+	themeSelect := widget.NewSelect([]string{"system", "light", "dark"}, func(selected string) {
+		cfg.Theme = selected
+	})
+	themeSelect.SetSelected(cfg.Theme)
+
+	// Auto-save interval
+	autoSaveEntry := intEntry(&cfg.AutoSaveInterval)
+
+	formItems := []*widget.FormItem{
+		widget.NewFormItem("Theme", themeSelect),
+		widget.NewFormItem("Auto-Save Interval (min, 0=off)", autoSaveEntry),
+		widget.NewFormItem("", widget.NewSeparator()),
+		widget.NewFormItem("Default Kerf Width (mm)", floatEntry(&cfg.DefaultKerfWidth)),
+		widget.NewFormItem("Default Edge Trim (mm)", floatEntry(&cfg.DefaultEdgeTrim)),
+		widget.NewFormItem("Default Tool Diameter (mm)", floatEntry(&cfg.DefaultToolDiameter)),
+		widget.NewFormItem("Default Feed Rate (mm/min)", floatEntry(&cfg.DefaultFeedRate)),
+		widget.NewFormItem("Default Plunge Rate (mm/min)", floatEntry(&cfg.DefaultPlungeRate)),
+		widget.NewFormItem("Default Spindle Speed (RPM)", intEntry(&cfg.DefaultSpindleSpeed)),
+		widget.NewFormItem("Default Safe Z (mm)", floatEntry(&cfg.DefaultSafeZ)),
+		widget.NewFormItem("Default Cut Depth (mm)", floatEntry(&cfg.DefaultCutDepth)),
+		widget.NewFormItem("Default Pass Depth (mm)", floatEntry(&cfg.DefaultPassDepth)),
+		widget.NewFormItem("Default GCode Profile", profileSelect),
+	}
+
+	d := dialog.NewForm("Settings", "Save", "Cancel", formItems,
+		func(ok bool) {
+			if !ok {
+				return
+			}
+			a.config = cfg
+			if err := a.saveConfig(); err != nil {
+				dialog.ShowError(fmt.Errorf("failed to save settings: %w", err), a.window)
+			} else {
+				dialog.ShowInformation("Settings Saved", "Application settings have been saved.", a.window)
+			}
+		},
+		a.window,
+	)
+	d.Resize(fyne.NewSize(500, 550))
+	d.Show()
+}
+
+// showImportExportDialog displays the import/export data dialog.
+func (a *App) showImportExportDialog() {
+	exportBtn := widget.NewButton("Export All Data...", func() {
+		d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+			if err != nil || writer == nil {
+				return
+			}
+			defer writer.Close()
+			path := writer.URI().Path()
+			if err := project.ExportAllData(path, a.config); err != nil {
+				dialog.ShowError(err, a.window)
+			} else {
+				dialog.ShowInformation("Export Complete",
+					fmt.Sprintf("All application data exported to:\n%s", path), a.window)
+			}
+		}, a.window)
+		d.SetFileName("slabcut-backup.json")
+		d.Show()
+	})
+
+	importBtn := widget.NewButton("Import All Data...", func() {
+		dialog.ShowConfirm("Import Data",
+			"Importing data will replace your current application settings.\n\nAre you sure you want to continue?",
+			func(ok bool) {
+				if !ok {
+					return
+				}
+				d := dialog.NewFileOpen(func(reader fyne.URIReadCloser, err error) {
+					if err != nil || reader == nil {
+						return
+					}
+					defer reader.Close()
+					path := reader.URI().Path()
+					backup, err := project.ImportAllData(path)
+					if err != nil {
+						dialog.ShowError(err, a.window)
+						return
+					}
+					a.config = backup.Config
+					if err := a.saveConfig(); err != nil {
+						dialog.ShowError(fmt.Errorf("failed to save imported settings: %w", err), a.window)
+						return
+					}
+					dialog.ShowInformation("Import Complete",
+						fmt.Sprintf("Data imported successfully from backup created at %s.", backup.CreatedAt), a.window)
+				}, a.window)
+				d.Show()
+			},
+			a.window,
+		)
+	})
+
+	content := container.NewVBox(
+		widget.NewLabel("Export all application data (settings, preferences) to a backup file,\nor import from a previously exported backup."),
+		widget.NewSeparator(),
+		exportBtn,
+		widget.NewSeparator(),
+		importBtn,
+	)
+
+	d := dialog.NewCustom("Import / Export Data", "Close", content, a.window)
+	d.Resize(fyne.NewSize(450, 250))
+	d.Show()
+}
+
+// saveConfig persists the current app config to disk.
+func (a *App) saveConfig() error {
+	return project.SaveAppConfig(project.DefaultConfigPath(), a.config)
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -25,6 +25,7 @@ import (
 type App struct {
 	window  fyne.Window
 	project model.Project
+	config  model.AppConfig
 	tabs    *container.AppTabs
 	history *History
 
@@ -36,9 +37,18 @@ type App struct {
 }
 
 func NewApp(window fyne.Window) *App {
+	cfg, err := project.LoadAppConfig(project.DefaultConfigPath())
+	if err != nil {
+		cfg = model.DefaultAppConfig()
+	}
+
+	proj := model.NewProject()
+	cfg.ApplyToSettings(&proj.Settings)
+
 	app := &App{
 		window:  window,
-		project: model.NewProject(),
+		project: proj,
+		config:  cfg,
 		history: NewHistory(),
 	}
 	app.loadCustomProfiles()
@@ -70,6 +80,7 @@ func (a *App) SetupMenus() {
 		fyne.NewMenuItem("New Project", func() {
 			a.saveState("New Project")
 			a.project = model.NewProject()
+			a.config.ApplyToSettings(&a.project.Settings)
 			a.refreshPartsList()
 			a.refreshStockList()
 			a.refreshResults()
@@ -139,6 +150,30 @@ func (a *App) SetupMenus() {
 		}),
 	)
 
+	// Admin Menu
+	adminMenu := fyne.NewMenu("Admin",
+		fyne.NewMenuItem("Parts Library...", func() {
+			dialog.ShowInformation("Parts Library",
+				"Coming soon — see issue #12 for progress.", a.window)
+		}),
+		fyne.NewMenuItem("Tool Inventory...", func() {
+			dialog.ShowInformation("Tool Inventory",
+				"Coming soon — see issue #11 for progress.", a.window)
+		}),
+		fyne.NewMenuItem("Stock Inventory...", func() {
+			dialog.ShowInformation("Stock Inventory",
+				"Coming soon — see issue #11 for progress.", a.window)
+		}),
+		fyne.NewMenuItemSeparator(),
+		fyne.NewMenuItem("Import/Export Data...", func() {
+			a.showImportExportDialog()
+		}),
+		fyne.NewMenuItemSeparator(),
+		fyne.NewMenuItem("Settings...", func() {
+			a.showSettingsDialog()
+		}),
+	)
+
 	// Help Menu
 	helpMenu := fyne.NewMenu("Help",
 		fyne.NewMenuItem("About", func() {
@@ -151,6 +186,7 @@ func (a *App) SetupMenus() {
 		fileMenu,
 		editMenu,
 		toolsMenu,
+		adminMenu,
 		helpMenu,
 	)
 	a.window.SetMainMenu(mainMenu)


### PR DESCRIPTION
## Summary

- Add top-level **Admin** menu between Tools and Help in the menu bar
- **Settings** dialog: edit application-wide defaults (CNC parameters, theme, auto-save interval, GCode profile) persisted to `~/.cnc-calculator/config.json`
- **Import/Export Data** dialog: export all app data as JSON backup, import from backup with confirmation
- **Parts Library**, **Tool Inventory**, **Stock Inventory**: placeholder menu items showing "Coming soon" dialogs (implemented in #11 and #12)
- New `AppConfig` model with `ApplyToSettings()` to propagate defaults to new projects
- Config auto-loads on app start; new projects inherit saved defaults
- Entry point added at `cmd/cnc-calculator/main.go`
- `.gitignore` fix: use `/cnc-calculator` to avoid ignoring `cmd/cnc-calculator/` directory

## Test plan

- [x] `go build ./cmd/cnc-calculator` compiles successfully
- [x] `go test ./...` passes (11 new tests across model and project packages)
- [ ] Launch app, verify Admin menu appears between Tools and Help
- [ ] Admin > Settings: change defaults, save, relaunch — verify values persist
- [ ] Admin > Import/Export: export data, modify settings, import backup — verify restore
- [ ] Admin > Parts Library / Tool Inventory / Stock Inventory show "Coming soon" dialogs
- [ ] File > New Project applies saved config defaults to CNC settings

Resolves #13