### PR TITLE
[Feature] Add zoomable/scrollable sheet layout canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 
 ### User Interface
 - **Visual Layout** — Color-coded sheet diagrams showing part placements and stock tab zones
+- **Zoomable Canvas** — Mouse wheel zoom (centered on cursor) and click-and-drag panning on sheet layout views, with zoom in/out buttons and reset
 - **Undo/Redo** — Full history with Ctrl+Z / Ctrl+Y (Cmd+Z / Cmd+Shift+Z on macOS)
 - **Parts Library** — Save and reuse predefined parts organized by category
 - **Tool & Stock Inventory** — Manage cutting tools and stock sheet presets

--- a/internal/ui/widgets/sheet_canvas.go
+++ b/internal/ui/widgets/sheet_canvas.go
@@ -3,10 +3,15 @@ package widgets
 import (
 	"fmt"
 	"image/color"
+	"math"
+	"sync"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/piwi3910/SlabCut/internal/model"
@@ -24,26 +29,138 @@ var partColors = []color.NRGBA{
 	{R: 121, G: 85, B: 72, A: 200},  // brown
 }
 
-// SheetCanvas renders a visual representation of a single sheet result.
+const (
+	minZoom     = 0.25
+	maxZoom     = 10.0
+	zoomStep    = 1.15 // multiplicative zoom factor per scroll notch
+	defaultZoom = 1.0
+)
+
+// SheetCanvas renders a visual representation of a single sheet result
+// with mouse wheel zoom and click-and-drag panning.
 type SheetCanvas struct {
 	widget.BaseWidget
 	sheet     model.SheetResult
 	settings  model.CutSettings
 	maxWidth  float32
 	maxHeight float32
+
+	// Zoom and pan state (protected by mutex for thread safety)
+	mu       sync.Mutex
+	zoom     float64
+	panX     float64 // pan offset in screen pixels
+	panY     float64
+	dragging bool
+	dragX    float32 // last drag position
+	dragY    float32
 }
 
+// NewSheetCanvas creates a new zoomable, pannable sheet canvas widget.
 func NewSheetCanvas(sheet model.SheetResult, settings model.CutSettings, maxW, maxH float32) *SheetCanvas {
 	sc := &SheetCanvas{
 		sheet:     sheet,
 		settings:  settings,
 		maxWidth:  maxW,
 		maxHeight: maxH,
+		zoom:      defaultZoom,
 	}
 	sc.ExtendBaseWidget(sc)
 	return sc
 }
 
+// Scrolled handles mouse wheel zoom, centered on the cursor position.
+func (sc *SheetCanvas) Scrolled(ev *fyne.ScrollEvent) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	oldZoom := sc.zoom
+
+	if ev.Scrolled.DY > 0 {
+		sc.zoom *= zoomStep
+	} else if ev.Scrolled.DY < 0 {
+		sc.zoom /= zoomStep
+	}
+	sc.zoom = math.Max(minZoom, math.Min(maxZoom, sc.zoom))
+
+	// Adjust pan to keep the point under cursor stationary.
+	cursorX := float64(ev.Position.X)
+	cursorY := float64(ev.Position.Y)
+	factor := sc.zoom / oldZoom
+	sc.panX = cursorX - (cursorX-sc.panX)*factor
+	sc.panY = cursorY - (cursorY-sc.panY)*factor
+
+	sc.Refresh()
+}
+
+// MouseDown starts a pan drag operation.
+func (sc *SheetCanvas) MouseDown(ev *desktop.MouseEvent) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.dragging = true
+	sc.dragX = ev.Position.X
+	sc.dragY = ev.Position.Y
+}
+
+// MouseUp ends a pan drag operation.
+func (sc *SheetCanvas) MouseUp(_ *desktop.MouseEvent) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.dragging = false
+}
+
+// MouseMoved pans the view while dragging.
+func (sc *SheetCanvas) MouseMoved(ev *desktop.MouseEvent) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	if !sc.dragging {
+		return
+	}
+
+	dx := float64(ev.Position.X - sc.dragX)
+	dy := float64(ev.Position.Y - sc.dragY)
+	sc.panX += dx
+	sc.panY += dy
+	sc.dragX = ev.Position.X
+	sc.dragY = ev.Position.Y
+
+	sc.Refresh()
+}
+
+// ResetZoom resets zoom to 1.0 and pan to origin.
+func (sc *SheetCanvas) ResetZoom() {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.zoom = defaultZoom
+	sc.panX = 0
+	sc.panY = 0
+	sc.Refresh()
+}
+
+// ZoomLevel returns the current zoom level.
+func (sc *SheetCanvas) ZoomLevel() float64 {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.zoom
+}
+
+// SetZoomCentered zooms in or out centered on the widget's center point.
+func (sc *SheetCanvas) SetZoomCentered(newZoom float64) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	oldZoom := sc.zoom
+	sc.zoom = math.Max(minZoom, math.Min(maxZoom, newZoom))
+	centerX := float64(sc.maxWidth) / 2
+	centerY := float64(sc.maxHeight) / 2
+	factor := sc.zoom / oldZoom
+	sc.panX = centerX - (centerX-sc.panX)*factor
+	sc.panY = centerY - (centerY-sc.panY)*factor
+
+	sc.Refresh()
+}
+
+// CreateRenderer returns the Fyne widget renderer for this canvas.
 func (sc *SheetCanvas) CreateRenderer() fyne.WidgetRenderer {
 	return newSheetCanvasRenderer(sc)
 }
@@ -66,21 +183,28 @@ func (r *sheetCanvasRenderer) rebuild() {
 	stockW := float32(sheet.Stock.Width)
 	stockH := float32(sheet.Stock.Height)
 
-	// Calculate scale to fit within max bounds
+	// Calculate base scale to fit within max bounds
 	scaleX := r.sc.maxWidth / stockW
 	scaleY := r.sc.maxHeight / stockH
-	scale := scaleX
-	if scaleY < scale {
-		scale = scaleY
+	baseScale := scaleX
+	if scaleY < baseScale {
+		baseScale = scaleY
 	}
 
+	r.sc.mu.Lock()
+	zoom := float32(r.sc.zoom)
+	panX := float32(r.sc.panX)
+	panY := float32(r.sc.panY)
+	r.sc.mu.Unlock()
+
+	scale := baseScale * zoom
 	canvasW := stockW * scale
 	canvasH := stockH * scale
 
 	// Stock sheet background
 	bg := canvas.NewRectangle(color.NRGBA{R: 210, G: 180, B: 140, A: 255}) // wood color
 	bg.Resize(fyne.NewSize(canvasW, canvasH))
-	bg.Move(fyne.NewPos(0, 0))
+	bg.Move(fyne.NewPos(panX, panY))
 	r.objects = append(r.objects, bg)
 
 	// Stock border
@@ -88,19 +212,19 @@ func (r *sheetCanvasRenderer) rebuild() {
 	border.StrokeColor = color.NRGBA{R: 100, G: 100, B: 100, A: 255}
 	border.StrokeWidth = 2
 	border.Resize(fyne.NewSize(canvasW, canvasH))
-	border.Move(fyne.NewPos(0, 0))
+	border.Move(fyne.NewPos(panX, panY))
 	r.objects = append(r.objects, border)
 
 	// Draw stock holding tabs (exclusion zones)
-	r.drawStockTabs(sheet.Stock, scale, canvasW, canvasH)
+	r.drawStockTabs(sheet.Stock, scale, panX, panY)
 
 	// Placed parts
 	for i, p := range sheet.Placements {
 		col := partColors[i%len(partColors)]
 		pw := float32(p.PlacedWidth()) * scale
 		ph := float32(p.PlacedHeight()) * scale
-		px := float32(p.X) * scale
-		py := float32(p.Y) * scale
+		px := float32(p.X)*scale + panX
+		py := float32(p.Y)*scale + panY
 
 		// Part rectangle
 		partRect := canvas.NewRectangle(col)
@@ -130,7 +254,7 @@ func (r *sheetCanvasRenderer) rebuild() {
 }
 
 // drawStockTabs visualizes stock sheet holding tab zones
-func (r *sheetCanvasRenderer) drawStockTabs(stock model.StockSheet, scale, canvasW, canvasH float32) {
+func (r *sheetCanvasRenderer) drawStockTabs(stock model.StockSheet, scale, panX, panY float32) {
 	// Get tab config for this sheet (use stock's override or global settings)
 	tabConfig := stock.Tabs
 	if !tabConfig.Enabled {
@@ -147,7 +271,6 @@ func (r *sheetCanvasRenderer) drawStockTabs(stock model.StockSheet, scale, canva
 		zones = tabConfig.CustomZones
 	} else {
 		// Simple mode: convert edge padding to zones
-		// Each edge becomes a zone along the full length
 		if tabConfig.TopPadding > 0 {
 			zones = append(zones, model.TabZone{
 				X:      0,
@@ -184,8 +307,8 @@ func (r *sheetCanvasRenderer) drawStockTabs(stock model.StockSheet, scale, canva
 
 	// Draw each zone as a semi-transparent red danger zone
 	for _, zone := range zones {
-		zx := float32(zone.X) * scale
-		zy := float32(zone.Y) * scale
+		zx := float32(zone.X)*scale + panX
+		zy := float32(zone.Y)*scale + panY
 		zw := float32(zone.Width) * scale
 		zh := float32(zone.Height) * scale
 
@@ -195,7 +318,7 @@ func (r *sheetCanvasRenderer) drawStockTabs(stock model.StockSheet, scale, canva
 		zoneRect.Move(fyne.NewPos(zx, zy))
 		r.objects = append(r.objects, zoneRect)
 
-		// Zone border (diagonal hatch pattern simulated with border)
+		// Zone border
 		zoneBorder := canvas.NewRectangle(color.Transparent)
 		zoneBorder.StrokeColor = color.NRGBA{R: 200, G: 0, B: 0, A: 255}
 		zoneBorder.StrokeWidth = 2
@@ -219,19 +342,11 @@ func (r *sheetCanvasRenderer) Refresh()                     { r.rebuild() }
 func (r *sheetCanvasRenderer) Destroy()                     {}
 func (r *sheetCanvasRenderer) Objects() []fyne.CanvasObject { return r.objects }
 func (r *sheetCanvasRenderer) MinSize() fyne.Size {
-	sheet := r.sc.sheet
-	stockW := float32(sheet.Stock.Width)
-	stockH := float32(sheet.Stock.Height)
-	scaleX := r.sc.maxWidth / stockW
-	scaleY := r.sc.maxHeight / stockH
-	scale := scaleX
-	if scaleY < scale {
-		scale = scaleY
-	}
-	return fyne.NewSize(stockW*scale, stockH*scale)
+	return fyne.NewSize(r.sc.maxWidth, r.sc.maxHeight)
 }
 
-// RenderSheetResults creates a scrollable container of all sheet results.
+// RenderSheetResults creates a scrollable container of all sheet results
+// with zoom controls and interactive canvases.
 func RenderSheetResults(result *model.OptimizeResult, settings model.CutSettings) fyne.CanvasObject {
 	if result == nil || len(result.Sheets) == 0 {
 		return widget.NewLabel("No results yet. Add parts and stock, then click Optimize.")
@@ -241,7 +356,7 @@ func RenderSheetResults(result *model.OptimizeResult, settings model.CutSettings
 
 	for i, sheet := range result.Sheets {
 		header := widget.NewLabel(fmt.Sprintf(
-			"Sheet %d: %s (%.0f × %.0f) — %d parts, %.1f%% efficiency",
+			"Sheet %d: %s (%.0f x %.0f) — %d parts, %.1f%% efficiency",
 			i+1, sheet.Stock.Label, sheet.Stock.Width, sheet.Stock.Height,
 			len(sheet.Placements), sheet.Efficiency(),
 		))
@@ -249,7 +364,37 @@ func RenderSheetResults(result *model.OptimizeResult, settings model.CutSettings
 
 		sheetCanvas := NewSheetCanvas(sheet, settings, 600, 400)
 
-		items = append(items, header, sheetCanvas, widget.NewSeparator())
+		// Zoom info label showing current zoom percentage
+		zoomLabel := widget.NewLabel("100%")
+
+		resetBtn := widget.NewButtonWithIcon("Reset Zoom", theme.ViewRestoreIcon(), func() {
+			sheetCanvas.ResetZoom()
+			zoomLabel.SetText("100%")
+		})
+
+		zoomInBtn := widget.NewButtonWithIcon("", theme.ZoomInIcon(), func() {
+			currentZoom := sheetCanvas.ZoomLevel()
+			newZoom := math.Min(maxZoom, currentZoom*zoomStep)
+			sheetCanvas.SetZoomCentered(newZoom)
+			zoomLabel.SetText(fmt.Sprintf("%.0f%%", sheetCanvas.ZoomLevel()*100))
+		})
+
+		zoomOutBtn := widget.NewButtonWithIcon("", theme.ZoomOutIcon(), func() {
+			currentZoom := sheetCanvas.ZoomLevel()
+			newZoom := math.Max(minZoom, currentZoom/zoomStep)
+			sheetCanvas.SetZoomCentered(newZoom)
+			zoomLabel.SetText(fmt.Sprintf("%.0f%%", sheetCanvas.ZoomLevel()*100))
+		})
+
+		zoomControls := container.NewHBox(
+			zoomOutBtn,
+			zoomLabel,
+			zoomInBtn,
+			layout.NewSpacer(),
+			resetBtn,
+		)
+
+		items = append(items, header, sheetCanvas, zoomControls, widget.NewSeparator())
 	}
 
 	if len(result.UnplacedParts) > 0 {
@@ -284,7 +429,6 @@ func RenderSheetResults(result *model.OptimizeResult, settings model.CutSettings
 }
 
 // buildStockSizeBreakdown generates per-stock-size statistics lines.
-// Groups sheets by their dimensions and reports count, total parts, and efficiency.
 func buildStockSizeBreakdown(result *model.OptimizeResult) []string {
 	if result == nil || len(result.Sheets) == 0 {
 		return nil
@@ -301,7 +445,6 @@ func buildStockSizeBreakdown(result *model.OptimizeResult) []string {
 		totalArea  float64
 	}
 
-	// Preserve insertion order with a slice of keys
 	var order []sizeKey
 	statsMap := make(map[sizeKey]*sizeStats)
 


### PR DESCRIPTION
## Summary
- Add mouse wheel zoom centered on cursor position to SheetCanvas widget
- Add click-and-drag panning when zoomed in
- Add zoom in/out buttons and reset zoom button below each sheet canvas
- Thread-safe zoom/pan state with sync.Mutex
- SheetCanvas implements Fyne Scrollable and desktop.Mouseable interfaces

## Test plan
- [ ] Run optimizer with parts and stock sheets
- [ ] Verify mouse wheel zooms centered on cursor
- [ ] Verify click-and-drag pans the view
- [ ] Verify zoom in/out buttons work
- [ ] Verify reset zoom button returns to default view
- [ ] Verify `go test ./...` passes
- [ ] Verify `go build ./cmd/slabcut` succeeds

Resolves #57