### PR TITLE
[Feature] Add sheet grain matching for part-to-stock grain alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 ### Optimization Engine
 - **2D Bin Packing** — Guillotine-based optimization with Best Area Fit heuristic
 - **Genetic Algorithm** — Alternative optimizer using population-based meta-heuristic for better packing efficiency
-- **Grain Direction** — Supports horizontal/vertical grain constraints
+- **Grain Direction** — Supports horizontal/vertical grain constraints on both parts and stock sheets with automatic grain matching
 - **Saw Kerf & Edge Trim** — Accounts for blade width and stock edge waste
 - **Part Rotation** — Automatically rotates parts for better fit (respects grain)
 - **Multiple Stock Sizes** — Use different stock sheet sizes in one run with smart selection (trial-packing heuristic)


### PR DESCRIPTION
## Summary
- Add `Grain` field to `StockSheet` model for specifying stock sheet grain direction
- Implement `CanPlaceWithGrain()` function for grain compatibility checking between parts and stock sheets
- Update guillotine and genetic algorithm optimizers to respect grain matching
- Add grain direction selection to stock sheet add/edit dialogs in UI
- Add comprehensive tests for all grain matching scenarios

## Test plan
- [x] All existing tests pass
- [x] New grain matching tests cover: matching grains, mismatched grains, no-grain parts/stocks, rotation prevention
- [x] Full build compiles successfully
- [x] `go test ./...` passes

Resolves #44