### PR TITLE
[Feature] Add GCode toolpath simulation with slider and playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
   - Safe Z retract between operations
   - Lead-in/lead-out arcs for smoother entry and exit
 - **GCode Preview** — Visual toolpath simulation with color-coded rapid/feed/plunge moves
+- **Toolpath Simulation** — Interactive GCode simulation with progress slider, play/pause/stop/step controls, adjustable speed (0.25x-16x), completed vs remaining cut visualization, and live tool position indicator
 - **Post-Processor Profiles** — Built-in profiles for Grbl, Mach3, LinuxCNC + custom user profiles
 - **DXF Part Outlines** — GCode follows actual part contours for non-rectangular shapes
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -849,28 +849,29 @@ func (a *App) previewGCode() {
 	// Legend header
 	legendLabel := widget.NewLabelWithStyle("Legend:", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 	legendText := widget.NewRichTextFromMarkdown(
-		"**Red dashed** = Rapid moves  |  **Blue solid** = Cutting moves  |  **Green dot** = Plunge  |  **Yellow dot** = Retract  |  **Orange** = Tab positions")
+		"**Green** = Completed cuts  |  **Dim blue** = Remaining cuts  |  **Red circle** = Tool position  |  **Orange** = Tab positions")
 	previewItems = append(previewItems, container.NewHBox(legendLabel, legendText), widget.NewSeparator())
 
 	for i, sheet := range a.project.Result.Sheets {
 		gcodeStr := gen.GenerateSheet(sheet, i+1)
 
 		header := widget.NewLabelWithStyle(
-			fmt.Sprintf("Sheet %d: %s (%.0f x %.0f) — Toolpath Preview",
+			fmt.Sprintf("Sheet %d: %s (%.0f x %.0f) — Toolpath Simulation",
 				i+1, sheet.Stock.Label, sheet.Stock.Width, sheet.Stock.Height),
 			fyne.TextAlignLeading, fyne.TextStyle{Bold: true},
 		)
 
-		preview := widgets.RenderGCodePreview(sheet, a.project.Settings, gcodeStr)
+		// Use simulation view with slider, play/pause, step, and speed controls
+		simView := widgets.RenderGCodeSimulation(sheet, a.project.Settings, gcodeStr)
 
-		previewItems = append(previewItems, header, preview, widget.NewSeparator())
+		previewItems = append(previewItems, header, simView, widget.NewSeparator())
 	}
 
 	content := container.NewVScroll(container.NewVBox(previewItems...))
-	content.SetMinSize(fyne.NewSize(750, 500))
+	content.SetMinSize(fyne.NewSize(750, 550))
 
-	d := dialog.NewCustom("GCode Toolpath Preview", "Close", content, a.window)
-	d.Resize(fyne.NewSize(800, 600))
+	d := dialog.NewCustom("GCode Toolpath Simulation", "Close", content, a.window)
+	d.Resize(fyne.NewSize(850, 650))
 	d.Show()
 }
 

--- a/internal/ui/widgets/gcode_preview.go
+++ b/internal/ui/widgets/gcode_preview.go
@@ -1,11 +1,17 @@
 package widgets
 
 import (
+	"fmt"
 	"image/color"
 	"math"
+	"sync"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/piwi3910/SlabCut/internal/gcode"
@@ -15,16 +21,22 @@ import (
 // Toolpath colors for different move types.
 var (
 	colorRapid   = color.NRGBA{R: 255, G: 60, B: 60, A: 200}   // Red for rapid moves
-	colorFeed    = color.NRGBA{R: 30, G: 120, B: 255, A: 230}  // Blue for cutting moves
-	colorPlunge  = color.NRGBA{R: 50, G: 200, B: 50, A: 220}   // Green for plunge
-	colorRetract = color.NRGBA{R: 180, G: 180, B: 0, A: 180}   // Yellow for retract
-	colorSheet   = color.NRGBA{R: 230, G: 210, B: 175, A: 255} // Light wood for stock
-	colorPart    = color.NRGBA{R: 200, G: 220, B: 255, A: 120} // Light blue for part outlines
-	colorTab     = color.NRGBA{R: 255, G: 165, B: 0, A: 220}   // Orange for tab markers
+	colorFeed    = color.NRGBA{R: 30, G: 120, B: 255, A: 230}   // Blue for cutting moves
+	colorPlunge  = color.NRGBA{R: 50, G: 200, B: 50, A: 220}    // Green for plunge
+	colorRetract = color.NRGBA{R: 180, G: 180, B: 0, A: 180}    // Yellow for retract
+	colorSheet   = color.NRGBA{R: 230, G: 210, B: 175, A: 255}  // Light wood for stock
+	colorPart    = color.NRGBA{R: 200, G: 220, B: 255, A: 120}  // Light blue for part outlines
+	colorTab     = color.NRGBA{R: 255, G: 165, B: 0, A: 220}    // Orange for tab markers
+	colorDimFeed = color.NRGBA{R: 30, G: 120, B: 255, A: 60}    // Dim blue for remaining feed moves
+	colorDimRap  = color.NRGBA{R: 255, G: 60, B: 60, A: 50}     // Dim red for remaining rapid moves
+	colorToolPos = color.NRGBA{R: 255, G: 0, B: 0, A: 255}      // Bright red for tool position
+	colorDoneFd  = color.NRGBA{R: 0, G: 200, B: 80, A: 230}     // Green for completed feed
+	colorDoneRap = color.NRGBA{R: 200, G: 100, B: 100, A: 130}  // Dim completed rapid
 )
 
 // GCodePreview is a custom Fyne widget that renders a visual preview
 // of GCode toolpath movements overlaid on a stock sheet with part outlines.
+// It supports simulation mode where only a subset of moves are shown as "completed".
 type GCodePreview struct {
 	widget.BaseWidget
 	moves      []gcode.GCodeMove
@@ -34,21 +46,45 @@ type GCodePreview struct {
 	sheetH     float64
 	maxWidth   float32
 	maxHeight  float32
+
+	// Simulation state: how many moves to show as completed.
+	// -1 means show all moves (no simulation mode / show everything).
+	mu           sync.Mutex
+	visibleMoves int
 }
 
 // NewGCodePreview creates a new GCode preview widget.
 func NewGCodePreview(moves []gcode.GCodeMove, placements []model.Placement, settings model.CutSettings, sheetW, sheetH float64, maxW, maxH float32) *GCodePreview {
 	gp := &GCodePreview{
-		moves:      moves,
-		placements: placements,
-		settings:   settings,
-		sheetW:     sheetW,
-		sheetH:     sheetH,
-		maxWidth:   maxW,
-		maxHeight:  maxH,
+		moves:        moves,
+		placements:   placements,
+		settings:     settings,
+		sheetW:       sheetW,
+		sheetH:       sheetH,
+		maxWidth:     maxW,
+		maxHeight:    maxH,
+		visibleMoves: -1, // show all by default
 	}
 	gp.ExtendBaseWidget(gp)
 	return gp
+}
+
+// SetVisibleMoves sets how many moves to show as "completed" in simulation mode.
+// Pass -1 to show all moves (no simulation). Pass 0 to show none completed.
+func (gp *GCodePreview) SetVisibleMoves(n int) {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+	if n >= len(gp.moves) {
+		gp.visibleMoves = -1
+	} else {
+		gp.visibleMoves = n
+	}
+	gp.Refresh()
+}
+
+// MoveCount returns the total number of GCode moves.
+func (gp *GCodePreview) MoveCount() int {
+	return len(gp.moves)
 }
 
 // CreateRenderer implements fyne.Widget.
@@ -143,45 +179,88 @@ func (r *gcodePreviewRenderer) rebuild() {
 		r.drawTabMarkers(scale, offsetX, offsetY)
 	}
 
+	gp.mu.Lock()
+	visibleMoves := gp.visibleMoves
+	gp.mu.Unlock()
+
+	simulating := visibleMoves >= 0
+
+	// Track tool position for simulation marker
+	var toolX, toolY float32
+	toolVisible := false
+
 	// Draw toolpath lines
-	for _, m := range gp.moves {
+	for i, m := range gp.moves {
 		fromX := float32(m.FromX)*scale + offsetX
 		fromY := float32(m.FromY)*scale + offsetY
 		toX := float32(m.ToX)*scale + offsetX
 		toY := float32(m.ToY)*scale + offsetY
 
-		// Skip zero-length moves and pure Z-only moves (plunge/retract shown as markers)
 		dx := m.ToX - m.FromX
 		dy := m.ToY - m.FromY
 		xyDist := math.Sqrt(dx*dx + dy*dy)
+
+		// Determine if this move is completed, current, or remaining
+		isCompleted := !simulating || i < visibleMoves
+		isCurrent := simulating && i == visibleMoves
+
+		if isCurrent {
+			toolX = toX
+			toolY = toY
+			toolVisible = true
+		}
 
 		switch m.Type {
 		case gcode.MoveRapid:
 			if xyDist < 0.01 {
 				continue
 			}
-			line := canvas.NewLine(colorRapid)
+			var lineColor color.NRGBA
+			if isCompleted {
+				lineColor = colorDoneRap
+			} else if simulating {
+				lineColor = colorDimRap
+			} else {
+				lineColor = colorRapid
+			}
+			line := canvas.NewLine(lineColor)
 			line.StrokeWidth = 1
 			line.Position1 = fyne.NewPos(fromX, fromY)
 			line.Position2 = fyne.NewPos(toX, toY)
 			r.objects = append(r.objects, line)
 
-			// Draw dashes along rapid moves for visual distinction
-			r.drawDashedOverlay(fromX, fromY, toX, toY, colorRapid)
+			if !simulating {
+				r.drawDashedOverlay(fromX, fromY, toX, toY, colorRapid)
+			}
 
 		case gcode.MoveFeed:
 			if xyDist < 0.01 {
 				continue
 			}
-			line := canvas.NewLine(colorFeed)
-			line.StrokeWidth = 2
+			var lineColor color.NRGBA
+			if isCompleted {
+				lineColor = colorDoneFd
+			} else if simulating {
+				lineColor = colorDimFeed
+			} else {
+				lineColor = colorFeed
+			}
+			strokeW := float32(2)
+			if isCompleted && simulating {
+				strokeW = 2.5
+			}
+			line := canvas.NewLine(lineColor)
+			line.StrokeWidth = strokeW
 			line.Position1 = fyne.NewPos(fromX, fromY)
 			line.Position2 = fyne.NewPos(toX, toY)
 			r.objects = append(r.objects, line)
 
 		case gcode.MovePlunge:
-			// Draw a small downward arrow marker at plunge position
-			marker := canvas.NewCircle(colorPlunge)
+			markerColor := colorPlunge
+			if simulating && !isCompleted {
+				markerColor = color.NRGBA{R: 50, G: 200, B: 50, A: 60}
+			}
+			marker := canvas.NewCircle(markerColor)
 			markerSize := float32(4)
 			marker.Resize(fyne.NewSize(markerSize, markerSize))
 			marker.Move(fyne.NewPos(fromX-markerSize/2, fromY-markerSize/2))
@@ -189,20 +268,46 @@ func (r *gcodePreviewRenderer) rebuild() {
 
 		case gcode.MoveRetract:
 			if xyDist < 0.01 {
-				// Pure Z retract: show small upward marker
-				marker := canvas.NewCircle(colorRetract)
+				markerColor := colorRetract
+				if simulating && !isCompleted {
+					markerColor = color.NRGBA{R: 180, G: 180, B: 0, A: 50}
+				}
+				marker := canvas.NewCircle(markerColor)
 				markerSize := float32(3)
 				marker.Resize(fyne.NewSize(markerSize, markerSize))
 				marker.Move(fyne.NewPos(fromX-markerSize/2, fromY-markerSize/2))
 				r.objects = append(r.objects, marker)
 			} else {
-				line := canvas.NewLine(colorRetract)
+				lineColor := colorRetract
+				if simulating && !isCompleted {
+					lineColor = color.NRGBA{R: 180, G: 180, B: 0, A: 50}
+				}
+				line := canvas.NewLine(lineColor)
 				line.StrokeWidth = 1
 				line.Position1 = fyne.NewPos(fromX, fromY)
 				line.Position2 = fyne.NewPos(toX, toY)
 				r.objects = append(r.objects, line)
 			}
 		}
+	}
+
+	// Draw tool position marker on top of everything
+	if toolVisible {
+		// Outer ring
+		outerSize := float32(12)
+		outer := canvas.NewCircle(color.Transparent)
+		outer.StrokeColor = colorToolPos
+		outer.StrokeWidth = 2
+		outer.Resize(fyne.NewSize(outerSize, outerSize))
+		outer.Move(fyne.NewPos(toolX-outerSize/2, toolY-outerSize/2))
+		r.objects = append(r.objects, outer)
+
+		// Inner dot
+		innerSize := float32(4)
+		inner := canvas.NewCircle(colorToolPos)
+		inner.Resize(fyne.NewSize(innerSize, innerSize))
+		inner.Move(fyne.NewPos(toolX-innerSize/2, toolY-innerSize/2))
+		r.objects = append(r.objects, inner)
 	}
 }
 
@@ -220,7 +325,6 @@ func (r *gcodePreviewRenderer) drawDashedOverlay(x1, y1, x2, y2 float32, col col
 	nx := dx / length
 	ny := dy / length
 
-	// Overlay background-colored segments for gaps
 	bgColor := colorSheet
 	cursor := dashLen
 	for cursor+gapLen < length {
@@ -237,14 +341,14 @@ func (r *gcodePreviewRenderer) drawDashedOverlay(x1, y1, x2, y2 float32, col col
 
 		cursor += dashLen + gapLen
 	}
-	_ = col // color parameter reserved for potential future use
+	_ = col
 }
 
 // drawTabMarkers draws small orange rectangles where holding tabs are positioned.
 func (r *gcodePreviewRenderer) drawTabMarkers(scale, offsetX, offsetY float32) {
 	settings := r.gp.settings
 	tabW := float32(settings.PartTabWidth) * scale
-	tabMarkerH := float32(3) // Fixed visual height for tab markers
+	tabMarkerH := float32(3)
 
 	for _, p := range r.gp.placements {
 		toolR := settings.ToolDiameter / 2.0
@@ -267,22 +371,22 @@ func (r *gcodePreviewRenderer) drawTabMarkers(scale, offsetX, offsetY float32) {
 				var tx, ty, tw, th float32
 
 				switch side {
-				case 0: // bottom: along X at y0
+				case 0:
 					tx = x0 + pos - tabW/2
 					ty = y0 - tabMarkerH/2
 					tw = tabW
 					th = tabMarkerH
-				case 1: // right: along Y at x0+pw*scale
+				case 1:
 					tx = x0 + float32(pw)*scale - tabMarkerH/2
 					ty = y0 + pos - tabW/2
 					tw = tabMarkerH
 					th = tabW
-				case 2: // top: along X at y0+ph*scale
+				case 2:
 					tx = x0 + float32(pw)*scale - pos - tabW/2
 					ty = y0 + float32(ph)*scale - tabMarkerH/2
 					tw = tabW
 					th = tabMarkerH
-				case 3: // left: along Y at x0
+				case 3:
 					tx = x0 - tabMarkerH/2
 					ty = y0 + float32(ph)*scale - pos - tabW/2
 					tw = tabMarkerH
@@ -325,8 +429,7 @@ func (r *gcodePreviewRenderer) MinSize() fyne.Size {
 	return fyne.NewSize(stockW*scale+margin*2, stockH*scale+margin*2)
 }
 
-// RenderGCodePreview creates a complete preview panel for a sheet's GCode output,
-// including the toolpath visualization and a color legend.
+// RenderGCodePreview creates a complete preview panel for a sheet's GCode output.
 func RenderGCodePreview(sheet model.SheetResult, settings model.CutSettings, gcodeStr string) fyne.CanvasObject {
 	moves := gcode.ParseGCode(gcodeStr)
 
@@ -340,4 +443,222 @@ func RenderGCodePreview(sheet model.SheetResult, settings model.CutSettings, gco
 	)
 
 	return preview
+}
+
+// SimulationSpeed defines playback speed multipliers.
+var simulationSpeeds = []struct {
+	Label      string
+	Multiplier float64
+}{
+	{"0.25x", 0.25},
+	{"0.5x", 0.5},
+	{"1x", 1.0},
+	{"2x", 2.0},
+	{"4x", 4.0},
+	{"8x", 8.0},
+	{"16x", 16.0},
+}
+
+// RenderGCodeSimulation creates a GCode preview panel with full simulation controls:
+// a progress slider, play/pause button, step forward/backward, speed control,
+// and move counter. Completed toolpath is shown in green, remaining in dim colors,
+// with a red crosshair showing current tool position.
+func RenderGCodeSimulation(sheet model.SheetResult, settings model.CutSettings, gcodeStr string) fyne.CanvasObject {
+	moves := gcode.ParseGCode(gcodeStr)
+	if len(moves) == 0 {
+		return widget.NewLabel("No toolpath moves found in GCode.")
+	}
+
+	preview := NewGCodePreview(
+		moves,
+		sheet.Placements,
+		settings,
+		sheet.Stock.Width,
+		sheet.Stock.Height,
+		700, 450,
+	)
+
+	totalMoves := preview.MoveCount()
+
+	// Start in "show all" mode (non-simulation)
+	preview.SetVisibleMoves(-1)
+
+	// State for playback
+	var playMu sync.Mutex
+	playing := false
+	var stopChan chan struct{}
+	speedIdx := 2 // default 1x
+
+	// UI elements
+	moveLabel := widget.NewLabel(fmt.Sprintf("Move: %d / %d", totalMoves, totalMoves))
+	moveLabel.TextStyle = fyne.TextStyle{Monospace: true}
+
+	slider := widget.NewSlider(0, float64(totalMoves))
+	slider.Value = float64(totalMoves)
+	slider.Step = 1
+
+	// Speed selector
+	speedNames := make([]string, len(simulationSpeeds))
+	for i, s := range simulationSpeeds {
+		speedNames[i] = s.Label
+	}
+	speedSelect := widget.NewSelect(speedNames, func(selected string) {
+		for i, s := range simulationSpeeds {
+			if s.Label == selected {
+				playMu.Lock()
+				speedIdx = i
+				playMu.Unlock()
+				break
+			}
+		}
+	})
+	speedSelect.SetSelected("1x")
+
+	var playBtn *widget.Button
+
+	updateDisplay := func(pos int) {
+		if pos >= totalMoves {
+			preview.SetVisibleMoves(-1) // show all
+			moveLabel.SetText(fmt.Sprintf("Move: %d / %d", totalMoves, totalMoves))
+		} else {
+			preview.SetVisibleMoves(pos)
+			moveLabel.SetText(fmt.Sprintf("Move: %d / %d", pos, totalMoves))
+		}
+	}
+
+	stopPlayback := func() {
+		playMu.Lock()
+		defer playMu.Unlock()
+		if playing {
+			playing = false
+			close(stopChan)
+		}
+		if playBtn != nil {
+			playBtn.SetIcon(theme.MediaPlayIcon())
+			playBtn.SetText("Play")
+		}
+	}
+
+	startPlayback := func() {
+		playMu.Lock()
+		if playing {
+			playMu.Unlock()
+			return
+		}
+		playing = true
+		stopChan = make(chan struct{})
+		ch := stopChan
+		playMu.Unlock()
+
+		if playBtn != nil {
+			playBtn.SetIcon(theme.MediaPauseIcon())
+			playBtn.SetText("Pause")
+		}
+
+		go func() {
+			pos := int(slider.Value)
+			if pos >= totalMoves {
+				pos = 0
+			}
+
+			for pos < totalMoves {
+				select {
+				case <-ch:
+					return
+				default:
+				}
+
+				pos++
+				slider.SetValue(float64(pos))
+				updateDisplay(pos)
+
+				playMu.Lock()
+				spd := simulationSpeeds[speedIdx].Multiplier
+				playMu.Unlock()
+
+				// Base interval: 50ms at 1x speed
+				interval := time.Duration(float64(50*time.Millisecond) / spd)
+				if interval < time.Millisecond {
+					interval = time.Millisecond
+				}
+				time.Sleep(interval)
+			}
+
+			// Reached end
+			playMu.Lock()
+			playing = false
+			playMu.Unlock()
+			if playBtn != nil {
+				playBtn.SetIcon(theme.MediaPlayIcon())
+				playBtn.SetText("Play")
+			}
+		}()
+	}
+
+	slider.OnChanged = func(val float64) {
+		updateDisplay(int(val))
+	}
+
+	playBtn = widget.NewButtonWithIcon("Play", theme.MediaPlayIcon(), func() {
+		playMu.Lock()
+		isPlaying := playing
+		playMu.Unlock()
+
+		if isPlaying {
+			stopPlayback()
+		} else {
+			startPlayback()
+		}
+	})
+
+	stopBtn := widget.NewButtonWithIcon("Stop", theme.MediaStopIcon(), func() {
+		stopPlayback()
+		slider.SetValue(0)
+		updateDisplay(0)
+	})
+
+	stepBackBtn := widget.NewButtonWithIcon("", theme.MediaSkipPreviousIcon(), func() {
+		stopPlayback()
+		pos := int(slider.Value) - 1
+		if pos < 0 {
+			pos = 0
+		}
+		slider.SetValue(float64(pos))
+		updateDisplay(pos)
+	})
+
+	stepFwdBtn := widget.NewButtonWithIcon("", theme.MediaSkipNextIcon(), func() {
+		stopPlayback()
+		pos := int(slider.Value) + 1
+		if pos > totalMoves {
+			pos = totalMoves
+		}
+		slider.SetValue(float64(pos))
+		updateDisplay(pos)
+	})
+
+	resetBtn := widget.NewButtonWithIcon("Show All", theme.ViewRestoreIcon(), func() {
+		stopPlayback()
+		slider.SetValue(float64(totalMoves))
+		updateDisplay(totalMoves)
+	})
+
+	// Layout: controls below the preview
+	controls := container.NewVBox(
+		slider,
+		container.NewHBox(
+			stepBackBtn,
+			playBtn,
+			stopBtn,
+			stepFwdBtn,
+			widget.NewSeparator(),
+			widget.NewLabel("Speed:"),
+			speedSelect,
+			layout.NewSpacer(),
+			moveLabel,
+			resetBtn,
+		),
+	)
+
+	return container.NewBorder(nil, controls, nil, nil, preview)
 }


### PR DESCRIPTION
## Summary
- Add interactive GCode toolpath simulation to the preview dialog
- Progress slider steps through all GCode moves, showing completed cuts (green) vs remaining (dim blue)
- Play/pause/stop/step-forward/step-backward controls for animated playback
- Speed control selector from 0.25x to 16x
- Live tool position indicator (red crosshair) tracks current position
- Move counter displays current position out of total moves

## Test plan
- [ ] Run optimizer with parts and stock
- [ ] Open GCode preview (Preview GCode button or File menu)
- [ ] Verify slider moves through toolpath and colors change
- [ ] Verify play/pause starts/stops animation
- [ ] Verify step buttons advance one move at a time
- [ ] Verify speed selector changes playback speed
- [ ] Verify "Show All" button returns to full view
- [ ] Verify `go test ./...` passes
- [ ] Verify `go build ./cmd/slabcut` succeeds

Resolves #58