### PR TITLE
[Feature] Add purchasing calculator for sheet count and cost estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Tool & Stock Inventory** — Manage cutting tools and stock sheet presets
 - **Material Pricing** — Track price per sheet in stock inventory; view total material cost in optimization results
 - **Offcuts / Remnants Tracking** — Automatically detects usable rectangular remnants after optimization; save offcuts to stock inventory for future projects
+- **Purchasing Calculator** — Calculate sheets needed, board feet, and estimated cost with configurable waste factor (Tools menu)
 - **Admin Menu** — Application settings, inventory management, data backup/restore
 - **Stock Size Presets** — Quick-select dropdown with common panel sizes (Full, Half, Quarter sheet, Euro sizes)
 

--- a/internal/model/calculator.go
+++ b/internal/model/calculator.go
@@ -1,0 +1,67 @@
+package model
+
+import "math"
+
+// PurchaseEstimate holds the results of a sheet purchasing calculation.
+type PurchaseEstimate struct {
+	TotalPartArea     float64 `json:"total_part_area"`      // Total area of all parts (sq mm)
+	TotalBoardFeet    float64 `json:"total_board_feet"`     // Total area in board feet (1 bf = 144 sq in = 92903.04 sq mm)
+	SheetArea         float64 `json:"sheet_area"`           // Area of one sheet (sq mm)
+	SheetsNeededExact float64 `json:"sheets_needed_exact"`  // Exact fractional number of sheets
+	SheetsNeededMin   int     `json:"sheets_needed_min"`    // Minimum sheets (ceiling of exact)
+	SheetsWithWaste   int     `json:"sheets_with_waste"`    // Recommended sheets including waste factor
+	WastePercent      float64 `json:"waste_percent"`        // Waste factor applied (e.g., 15 for 15%)
+	EstimatedCost     float64 `json:"estimated_cost"`       // Total cost if pricing available
+	PricePerSheet     float64 `json:"price_per_sheet"`      // Price used for estimation
+	KerfWidth         float64 `json:"kerf_width"`           // Kerf width used in calculation
+}
+
+// sqmmPerBoardFoot is the number of square millimeters in one board foot.
+// 1 board foot = 12" x 12" x 1" (area) = 144 sq inches = 144 * 645.16 sq mm = 92903.04 sq mm.
+const sqmmPerBoardFoot = 92903.04
+
+// CalculatePurchaseEstimate computes how many sheets to buy for a given cut list.
+// It accounts for kerf waste and an additional waste percentage factor.
+func CalculatePurchaseEstimate(parts []Part, sheetWidth, sheetHeight, kerfWidth, wastePercent, pricePerSheet float64) PurchaseEstimate {
+	// Calculate total part area including kerf allowance per part
+	var totalPartArea float64
+	for _, p := range parts {
+		partW := p.Width + kerfWidth
+		partH := p.Height + kerfWidth
+		totalPartArea += partW * partH * float64(p.Quantity)
+	}
+
+	sheetArea := sheetWidth * sheetHeight
+	if sheetArea <= 0 {
+		return PurchaseEstimate{
+			TotalPartArea:  totalPartArea,
+			TotalBoardFeet: totalPartArea / sqmmPerBoardFoot,
+			WastePercent:   wastePercent,
+		}
+	}
+
+	exactSheets := totalPartArea / sheetArea
+	minSheets := int(math.Ceil(exactSheets))
+
+	// Apply waste factor
+	wasteFactor := 1.0 + (wastePercent / 100.0)
+	sheetsWithWaste := int(math.Ceil(exactSheets * wasteFactor))
+	if sheetsWithWaste < minSheets {
+		sheetsWithWaste = minSheets
+	}
+
+	estimatedCost := float64(sheetsWithWaste) * pricePerSheet
+
+	return PurchaseEstimate{
+		TotalPartArea:     totalPartArea,
+		TotalBoardFeet:    totalPartArea / sqmmPerBoardFoot,
+		SheetArea:         sheetArea,
+		SheetsNeededExact: exactSheets,
+		SheetsNeededMin:   minSheets,
+		SheetsWithWaste:   sheetsWithWaste,
+		WastePercent:      wastePercent,
+		EstimatedCost:     estimatedCost,
+		PricePerSheet:     pricePerSheet,
+		KerfWidth:         kerfWidth,
+	}
+}

--- a/internal/model/calculator_test.go
+++ b/internal/model/calculator_test.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalculatePurchaseEstimateBasic(t *testing.T) {
+	parts := []Part{
+		{Label: "Part1", Width: 500, Height: 300, Quantity: 4},
+	}
+	est := CalculatePurchaseEstimate(parts, 2440, 1220, 3.0, 15.0, 45.00)
+
+	// Each part with kerf: 503 x 303 = 152409 sq mm, x4 = 609636
+	expectedArea := 503.0 * 303.0 * 4
+	if math.Abs(est.TotalPartArea-expectedArea) > 0.1 {
+		t.Errorf("expected total area %.1f, got %.1f", expectedArea, est.TotalPartArea)
+	}
+
+	if est.TotalBoardFeet <= 0 {
+		t.Error("expected positive board feet")
+	}
+
+	if est.SheetsNeededMin < 1 {
+		t.Error("expected at least 1 sheet")
+	}
+
+	if est.SheetsWithWaste < est.SheetsNeededMin {
+		t.Error("sheets with waste should be >= minimum sheets")
+	}
+
+	if est.EstimatedCost <= 0 {
+		t.Error("expected positive cost")
+	}
+}
+
+func TestCalculatePurchaseEstimateZeroSheetArea(t *testing.T) {
+	parts := []Part{
+		{Label: "P1", Width: 100, Height: 100, Quantity: 1},
+	}
+	est := CalculatePurchaseEstimate(parts, 0, 0, 0, 10, 0)
+	if est.SheetsNeededMin != 0 {
+		t.Errorf("expected 0 sheets for zero sheet area, got %d", est.SheetsNeededMin)
+	}
+	if est.TotalPartArea <= 0 {
+		t.Error("expected positive total part area even with zero sheet")
+	}
+}
+
+func TestCalculatePurchaseEstimateMultipleParts(t *testing.T) {
+	parts := []Part{
+		{Label: "Shelf", Width: 800, Height: 300, Quantity: 6},
+		{Label: "Side", Width: 600, Height: 400, Quantity: 2},
+		{Label: "Back", Width: 1200, Height: 800, Quantity: 1},
+	}
+	est := CalculatePurchaseEstimate(parts, 2440, 1220, 3.2, 20.0, 55.00)
+
+	if est.SheetsNeededMin < 1 {
+		t.Error("expected at least 1 sheet")
+	}
+	if est.SheetsWithWaste < est.SheetsNeededMin {
+		t.Errorf("waste sheets (%d) < min sheets (%d)", est.SheetsWithWaste, est.SheetsNeededMin)
+	}
+	if est.EstimatedCost != float64(est.SheetsWithWaste)*55.00 {
+		t.Errorf("expected cost %.2f, got %.2f", float64(est.SheetsWithWaste)*55.00, est.EstimatedCost)
+	}
+}
+
+func TestCalculatePurchaseEstimateNoWaste(t *testing.T) {
+	parts := []Part{
+		{Label: "P1", Width: 500, Height: 300, Quantity: 1},
+	}
+	est := CalculatePurchaseEstimate(parts, 2440, 1220, 0, 0, 0)
+	if est.SheetsNeededMin != 1 {
+		t.Errorf("expected 1 sheet, got %d", est.SheetsNeededMin)
+	}
+	if est.SheetsWithWaste != 1 {
+		t.Errorf("expected 1 sheet with 0%% waste, got %d", est.SheetsWithWaste)
+	}
+}
+
+func TestCalculatePurchaseEstimateExactFit(t *testing.T) {
+	// Parts that exactly fill one sheet
+	parts := []Part{
+		{Label: "Full", Width: 2440, Height: 1220, Quantity: 1},
+	}
+	est := CalculatePurchaseEstimate(parts, 2440, 1220, 0, 0, 30.00)
+	if est.SheetsNeededMin != 1 {
+		t.Errorf("expected exactly 1 sheet, got %d", est.SheetsNeededMin)
+	}
+}
+
+func TestBoardFeetConversion(t *testing.T) {
+	// 1 board foot = 144 sq in = 92903.04 sq mm
+	parts := []Part{
+		{Label: "P1", Width: 304.8, Height: 304.8, Quantity: 1}, // ~12" x 12" = 1 board foot
+	}
+	est := CalculatePurchaseEstimate(parts, 2440, 1220, 0, 0, 0)
+	// 304.8 * 304.8 = 92903.04 sq mm = exactly 1 board foot
+	if math.Abs(est.TotalBoardFeet-1.0) > 0.01 {
+		t.Errorf("expected ~1.0 board feet, got %.4f", est.TotalBoardFeet)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -186,6 +186,10 @@ func (a *App) SetupMenus() {
 			a.tabs.SelectIndex(3) // Switch to Results tab
 		}),
 		fyne.NewMenuItemSeparator(),
+		fyne.NewMenuItem("Purchasing Calculator...", func() {
+			a.showPurchasingCalculator()
+		}),
+		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Manage GCode Profiles...", func() {
 			a.showProfileManager()
 		}),
@@ -911,6 +915,113 @@ func (a *App) previewGCode() {
 	d := dialog.NewCustom("GCode Toolpath Simulation", "Close", content, a.window)
 	d.Resize(fyne.NewSize(850, 650))
 	d.Show()
+}
+
+// showPurchasingCalculator displays a dialog that calculates how many sheets to purchase.
+func (a *App) showPurchasingCalculator() {
+	if len(a.project.Parts) == 0 {
+		dialog.ShowInformation("No Parts", "Add parts to the project first.", a.window)
+		return
+	}
+
+	// Default sheet size from first stock or inventory
+	defaultW := 2440.0
+	defaultH := 1220.0
+	defaultPrice := 0.0
+	if len(a.project.Stocks) > 0 {
+		defaultW = a.project.Stocks[0].Width
+		defaultH = a.project.Stocks[0].Height
+		defaultPrice = a.project.Stocks[0].PricePerSheet
+	}
+
+	sheetWidthEntry := widget.NewEntry()
+	sheetWidthEntry.SetText(fmt.Sprintf("%.0f", defaultW))
+
+	sheetHeightEntry := widget.NewEntry()
+	sheetHeightEntry.SetText(fmt.Sprintf("%.0f", defaultH))
+
+	wasteEntry := widget.NewEntry()
+	wasteEntry.SetText("15")
+
+	priceEntry := widget.NewEntry()
+	priceEntry.SetText(fmt.Sprintf("%.2f", defaultPrice))
+
+	resultLabel := widget.NewLabel("")
+	resultLabel.Wrapping = fyne.TextWrapWord
+
+	calculateBtn := widget.NewButton("Calculate", func() {
+		sw, _ := strconv.ParseFloat(sheetWidthEntry.Text, 64)
+		sh, _ := strconv.ParseFloat(sheetHeightEntry.Text, 64)
+		waste, _ := strconv.ParseFloat(wasteEntry.Text, 64)
+		price, _ := strconv.ParseFloat(priceEntry.Text, 64)
+
+		if sw <= 0 || sh <= 0 {
+			resultLabel.SetText("Sheet dimensions must be > 0")
+			return
+		}
+
+		est := model.CalculatePurchaseEstimate(a.project.Parts, sw, sh,
+			a.project.Settings.KerfWidth, waste, price)
+
+		var text strings.Builder
+		text.WriteString(fmt.Sprintf("Total part area: %.0f sq mm (%.2f board feet)\n", est.TotalPartArea, est.TotalBoardFeet))
+		text.WriteString(fmt.Sprintf("Sheet area: %.0f sq mm (%.0f x %.0f)\n", est.SheetArea, sw, sh))
+		text.WriteString(fmt.Sprintf("Kerf width: %.1f mm\n\n", est.KerfWidth))
+		text.WriteString(fmt.Sprintf("Sheets needed (minimum): %d\n", est.SheetsNeededMin))
+		text.WriteString(fmt.Sprintf("Sheets recommended (with %.0f%% waste): %d\n", waste, est.SheetsWithWaste))
+		if price > 0 {
+			text.WriteString(fmt.Sprintf("\nEstimated cost: %.2f (%d sheets x %.2f/sheet)\n",
+				est.EstimatedCost, est.SheetsWithWaste, price))
+		}
+
+		resultLabel.SetText(text.String())
+	})
+	calculateBtn.Importance = widget.HighImportance
+
+	// Stock preset dropdown for quick selection
+	presetNames := a.inventory.StockNames()
+	presetSelect := widget.NewSelect(presetNames, func(selected string) {
+		preset := a.inventory.FindStockByName(selected)
+		if preset == nil {
+			return
+		}
+		sheetWidthEntry.SetText(fmt.Sprintf("%.0f", preset.Width))
+		sheetHeightEntry.SetText(fmt.Sprintf("%.0f", preset.Height))
+		if preset.PricePerSheet > 0 {
+			priceEntry.SetText(fmt.Sprintf("%.2f", preset.PricePerSheet))
+		}
+	})
+	presetSelect.PlaceHolder = "Load from stock inventory..."
+
+	content := container.NewVBox(
+		widget.NewLabelWithStyle("Purchasing Calculator", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabel(fmt.Sprintf("Parts in project: %d types, %d total pieces",
+			len(a.project.Parts), countTotalParts(a.project.Parts))),
+		widget.NewSeparator(),
+		widget.NewFormItem("Stock Preset", presetSelect).Widget,
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Sheet Width (mm)"), sheetWidthEntry,
+			widget.NewLabel("Sheet Height (mm)"), sheetHeightEntry,
+			widget.NewLabel("Waste Factor (%)"), wasteEntry,
+			widget.NewLabel("Price per Sheet"), priceEntry,
+		),
+		calculateBtn,
+		widget.NewSeparator(),
+		resultLabel,
+	)
+
+	d := dialog.NewCustom("Purchasing Calculator", "Close", content, a.window)
+	d.Resize(fyne.NewSize(500, 550))
+	d.Show()
+}
+
+// countTotalParts sums up all part quantities.
+func countTotalParts(parts []model.Part) int {
+	total := 0
+	for _, p := range parts {
+		total += p.Quantity
+	}
+	return total
 }
 
 // saveOffcutsToInventory detects usable offcuts from the current result and saves them


### PR DESCRIPTION
## Summary
- Adds `CalculatePurchaseEstimate` function that computes total part area, board feet, minimum sheets, recommended sheets with waste factor, and estimated cost
- Adds purchasing calculator dialog in Tools menu with stock preset integration
- Supports configurable waste percentage and per-sheet pricing
- Board feet conversion for US/imperial users

## Test plan
- [x] Unit tests for basic calculation, zero sheet area, multiple parts, no waste, exact fit, board feet conversion
- [x] All existing tests pass
- [x] Build succeeds

Resolves #37