### PR TITLE
[Feature] Add edge banding length calculator with per-edge flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Material Pricing** — Track price per sheet in stock inventory; view total material cost in optimization results
 - **Offcuts / Remnants Tracking** — Automatically detects usable rectangular remnants after optimization; save offcuts to stock inventory for future projects
 - **Purchasing Calculator** — Calculate sheets needed, board feet, and estimated cost with configurable waste factor (Tools menu)
+- **Edge Banding Calculator** — Mark which edges need banding per part (T/B/L/R); view per-part and total banding length with waste factor in results
 - **Admin Menu** — Application settings, inventory management, data backup/restore
 - **Stock Size Presets** — Quick-select dropdown with common panel sizes (Full, Half, Quarter sheet, Euro sizes)
 

--- a/internal/model/edgebanding.go
+++ b/internal/model/edgebanding.go
@@ -1,0 +1,78 @@
+package model
+
+import "math"
+
+// EdgeBandingSummary holds the calculated edge banding requirements for a project.
+type EdgeBandingSummary struct {
+	TotalLinearMM    float64 `json:"total_linear_mm"`    // Total banding length in mm (no waste)
+	TotalLinearM     float64 `json:"total_linear_m"`     // Total banding length in meters (no waste)
+	WastePercent     float64 `json:"waste_percent"`      // Waste percentage applied
+	TotalWithWasteMM float64 `json:"total_with_waste_mm"` // Total with waste in mm
+	TotalWithWasteM  float64 `json:"total_with_waste_m"`  // Total with waste in meters
+	PartCount        int     `json:"part_count"`          // Number of individual pieces needing banding
+	EdgeCount        int     `json:"edge_count"`          // Total number of edges needing banding
+}
+
+// CalculateEdgeBanding computes the total edge banding needed for a list of parts.
+// wastePercent is the additional percentage to add for waste (e.g., 10 for 10%).
+func CalculateEdgeBanding(parts []Part, wastePercent float64) EdgeBandingSummary {
+	var totalMM float64
+	var partCount, edgeCount int
+
+	for _, p := range parts {
+		if !p.EdgeBanding.HasAny() {
+			continue
+		}
+		lengthPerPiece := p.EdgeBanding.LinearLength(p.Width, p.Height)
+		edgesPerPiece := p.EdgeBanding.EdgeCount()
+
+		totalMM += lengthPerPiece * float64(p.Quantity)
+		partCount += p.Quantity
+		edgeCount += edgesPerPiece * p.Quantity
+	}
+
+	wasteFactor := 1.0 + (wastePercent / 100.0)
+	totalWithWaste := totalMM * wasteFactor
+
+	return EdgeBandingSummary{
+		TotalLinearMM:    totalMM,
+		TotalLinearM:     totalMM / 1000.0,
+		WastePercent:     wastePercent,
+		TotalWithWasteMM: math.Ceil(totalWithWaste), // Round up
+		TotalWithWasteM:  math.Ceil(totalWithWaste) / 1000.0,
+		PartCount:        partCount,
+		EdgeCount:        edgeCount,
+	}
+}
+
+// PerPartEdgeBanding returns a per-part breakdown of edge banding needs.
+type PerPartEdgeBanding struct {
+	Label         string  `json:"label"`
+	Width         float64 `json:"width"`
+	Height        float64 `json:"height"`
+	Quantity      int     `json:"quantity"`
+	Edges         string  `json:"edges"`          // e.g., "T+B+L+R"
+	LengthPerUnit float64 `json:"length_per_unit"` // mm per piece
+	TotalLength   float64 `json:"total_length"`    // mm for all pieces
+}
+
+// CalculatePerPartEdgeBanding returns a breakdown of banding per part type.
+func CalculatePerPartEdgeBanding(parts []Part) []PerPartEdgeBanding {
+	var results []PerPartEdgeBanding
+	for _, p := range parts {
+		if !p.EdgeBanding.HasAny() {
+			continue
+		}
+		lengthPerUnit := p.EdgeBanding.LinearLength(p.Width, p.Height)
+		results = append(results, PerPartEdgeBanding{
+			Label:         p.Label,
+			Width:         p.Width,
+			Height:        p.Height,
+			Quantity:      p.Quantity,
+			Edges:         p.EdgeBanding.String(),
+			LengthPerUnit: lengthPerUnit,
+			TotalLength:   lengthPerUnit * float64(p.Quantity),
+		})
+	}
+	return results
+}

--- a/internal/model/edgebanding_test.go
+++ b/internal/model/edgebanding_test.go
@@ -1,0 +1,153 @@
+package model
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEdgeBandingHasAny(t *testing.T) {
+	none := EdgeBanding{}
+	if none.HasAny() {
+		t.Error("expected HasAny() false for no edges")
+	}
+
+	top := EdgeBanding{Top: true}
+	if !top.HasAny() {
+		t.Error("expected HasAny() true for top edge")
+	}
+}
+
+func TestEdgeBandingEdgeCount(t *testing.T) {
+	tests := []struct {
+		eb   EdgeBanding
+		want int
+	}{
+		{EdgeBanding{}, 0},
+		{EdgeBanding{Top: true}, 1},
+		{EdgeBanding{Top: true, Bottom: true}, 2},
+		{EdgeBanding{Top: true, Bottom: true, Left: true, Right: true}, 4},
+	}
+	for _, tt := range tests {
+		if got := tt.eb.EdgeCount(); got != tt.want {
+			t.Errorf("EdgeCount() = %d, want %d for %+v", got, tt.want, tt.eb)
+		}
+	}
+}
+
+func TestEdgeBandingLinearLength(t *testing.T) {
+	eb := EdgeBanding{Top: true, Bottom: true, Left: true, Right: true}
+	// Width=800, Height=400: top(800) + bottom(800) + left(400) + right(400) = 2400
+	length := eb.LinearLength(800, 400)
+	if length != 2400 {
+		t.Errorf("expected 2400, got %.0f", length)
+	}
+
+	// Only top and left
+	eb2 := EdgeBanding{Top: true, Left: true}
+	length2 := eb2.LinearLength(600, 300)
+	if length2 != 900 {
+		t.Errorf("expected 900, got %.0f", length2)
+	}
+}
+
+func TestEdgeBandingString(t *testing.T) {
+	tests := []struct {
+		eb   EdgeBanding
+		want string
+	}{
+		{EdgeBanding{}, "None"},
+		{EdgeBanding{Top: true}, "T"},
+		{EdgeBanding{Top: true, Bottom: true}, "T+B"},
+		{EdgeBanding{Top: true, Bottom: true, Left: true, Right: true}, "T+B+L+R"},
+		{EdgeBanding{Left: true, Right: true}, "L+R"},
+	}
+	for _, tt := range tests {
+		if got := tt.eb.String(); got != tt.want {
+			t.Errorf("String() = %q, want %q for %+v", got, tt.want, tt.eb)
+		}
+	}
+}
+
+func TestCalculateEdgeBanding(t *testing.T) {
+	parts := []Part{
+		{
+			Label: "Shelf", Width: 800, Height: 300, Quantity: 4,
+			EdgeBanding: EdgeBanding{Top: true, Bottom: true},
+		},
+		{
+			Label: "Side", Width: 600, Height: 400, Quantity: 2,
+			EdgeBanding: EdgeBanding{Top: true, Left: true, Right: true},
+		},
+		{
+			Label: "Back", Width: 500, Height: 300, Quantity: 1,
+			// No edge banding
+		},
+	}
+
+	summary := CalculateEdgeBanding(parts, 10.0)
+
+	// Shelf: (800+800) * 4 = 6400
+	// Side: (600+400+400) * 2 = 2800
+	// Total: 9200
+	expectedMM := 9200.0
+	if math.Abs(summary.TotalLinearMM-expectedMM) > 0.1 {
+		t.Errorf("expected %.0f mm, got %.0f mm", expectedMM, summary.TotalLinearMM)
+	}
+
+	if summary.PartCount != 6 { // 4 shelves + 2 sides
+		t.Errorf("expected 6 parts, got %d", summary.PartCount)
+	}
+
+	if summary.EdgeCount != 14 { // 4*2 + 2*3
+		t.Errorf("expected 14 edges, got %d", summary.EdgeCount)
+	}
+
+	// With 10% waste: 9200 * 1.1 = 10120
+	expectedWithWaste := math.Ceil(9200.0 * 1.1)
+	if summary.TotalWithWasteMM != expectedWithWaste {
+		t.Errorf("expected %.0f mm with waste, got %.0f mm", expectedWithWaste, summary.TotalWithWasteMM)
+	}
+}
+
+func TestCalculateEdgeBandingNoParts(t *testing.T) {
+	summary := CalculateEdgeBanding(nil, 10.0)
+	if summary.TotalLinearMM != 0 {
+		t.Errorf("expected 0 mm for no parts, got %.0f", summary.TotalLinearMM)
+	}
+}
+
+func TestCalculateEdgeBandingNoEdges(t *testing.T) {
+	parts := []Part{
+		{Label: "P1", Width: 100, Height: 100, Quantity: 5},
+	}
+	summary := CalculateEdgeBanding(parts, 15.0)
+	if summary.TotalLinearMM != 0 {
+		t.Errorf("expected 0 mm for parts without banding, got %.0f", summary.TotalLinearMM)
+	}
+}
+
+func TestCalculatePerPartEdgeBanding(t *testing.T) {
+	parts := []Part{
+		{
+			Label: "Shelf", Width: 800, Height: 300, Quantity: 4,
+			EdgeBanding: EdgeBanding{Top: true},
+		},
+		{
+			Label: "No banding", Width: 500, Height: 500, Quantity: 1,
+		},
+	}
+
+	breakdown := CalculatePerPartEdgeBanding(parts)
+	if len(breakdown) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(breakdown))
+	}
+	if breakdown[0].Label != "Shelf" {
+		t.Errorf("expected Shelf, got %s", breakdown[0].Label)
+	}
+	if breakdown[0].LengthPerUnit != 800 {
+		t.Errorf("expected 800 mm/unit, got %.0f", breakdown[0].LengthPerUnit)
+	}
+	if breakdown[0].TotalLength != 3200 {
+		t.Errorf("expected 3200 mm total, got %.0f", breakdown[0].TotalLength)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `EdgeBanding` struct with Top/Bottom/Left/Right boolean flags to `Part` type
- Adds per-edge linear length calculation, edge counting, and display formatting
- Adds `CalculateEdgeBanding` for total project banding needs with waste factor
- Adds `CalculatePerPartEdgeBanding` for per-part breakdown
- Adds "Banding" column to parts list showing active edges (e.g., "T+B+L+R")
- Adds edge banding checkboxes to add/edit part dialogs
- Shows edge banding summary in optimization results (per-part breakdown + totals with waste)

## Test plan
- [x] Unit tests for EdgeBanding HasAny, EdgeCount, LinearLength, String
- [x] Tests for CalculateEdgeBanding with various part combinations
- [x] Tests for per-part breakdown, no parts, no edges cases
- [x] All existing tests pass
- [x] Build succeeds

Resolves #48