### PR TITLE
[Feature] Add fixture/clamp zone definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Saw Kerf & Edge Trim** — Accounts for blade width and stock edge waste
 - **Part Rotation** — Automatically rotates parts for better fit (respects grain)
 - **Multiple Stock Sizes** — Use different stock sheet sizes in one run with smart selection (trial-packing heuristic)
+- **Fixture / Clamp Zones** — Define rectangular exclusion zones for clamps and fixtures; optimizer avoids placing parts in these areas
 
 ### CNC & GCode
 - **GCode Export** — Full CNC toolpath generation with:

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -162,3 +162,50 @@ func TestBuiltInProfilesMarkedCorrectly(t *testing.T) {
 		}
 	}
 }
+
+func TestClampZoneOverlaps(t *testing.T) {
+	cz := ClampZone{Label: "Test", X: 100, Y: 100, Width: 50, Height: 50}
+
+	tests := []struct {
+		name     string
+		x, y     float64
+		w, h     float64
+		expected bool
+	}{
+		{"fully inside", 110, 110, 20, 20, true},
+		{"overlapping top-left", 80, 80, 30, 30, true},
+		{"overlapping bottom-right", 140, 140, 20, 20, true},
+		{"adjacent left (no overlap)", 50, 100, 50, 50, false},
+		{"adjacent right (no overlap)", 150, 100, 50, 50, false},
+		{"adjacent top (no overlap)", 100, 50, 50, 50, false},
+		{"adjacent bottom (no overlap)", 100, 150, 50, 50, false},
+		{"completely outside", 200, 200, 50, 50, false},
+		{"covering entire zone", 50, 50, 200, 200, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cz.Overlaps(tt.x, tt.y, tt.w, tt.h)
+			if result != tt.expected {
+				t.Errorf("ClampZone.Overlaps(%v, %v, %v, %v) = %v, want %v",
+					tt.x, tt.y, tt.w, tt.h, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClampZoneToTabZone(t *testing.T) {
+	cz := ClampZone{Label: "Test", X: 10, Y: 20, Width: 30, Height: 40, ZHeight: 25}
+	tz := cz.ToTabZone()
+
+	if tz.X != 10 || tz.Y != 20 || tz.Width != 30 || tz.Height != 40 {
+		t.Errorf("ToTabZone() produced incorrect values: %+v", tz)
+	}
+}
+
+func TestDefaultSettingsHasNoClampZones(t *testing.T) {
+	s := DefaultSettings()
+	if len(s.ClampZones) != 0 {
+		t.Errorf("expected no clamp zones by default, got %d", len(s.ClampZones))
+	}
+}

--- a/internal/ui/widgets/sheet_canvas.go
+++ b/internal/ui/widgets/sheet_canvas.go
@@ -218,6 +218,9 @@ func (r *sheetCanvasRenderer) rebuild() {
 	// Draw stock holding tabs (exclusion zones)
 	r.drawStockTabs(sheet.Stock, scale, panX, panY)
 
+	// Draw clamp/fixture zones
+	r.drawClampZones(scale, panX, panY)
+
 	// Placed parts
 	for i, p := range sheet.Placements {
 		col := partColors[i%len(partColors)]
@@ -333,6 +336,43 @@ func (r *sheetCanvasRenderer) drawStockTabs(stock model.StockSheet, scale, panX,
 			label.TextStyle = fyne.TextStyle{Bold: true}
 			label.Move(fyne.NewPos(zx+5, zy+2))
 			r.objects = append(r.objects, label)
+		}
+	}
+}
+
+// drawClampZones visualizes fixture/clamp exclusion zones on the sheet.
+func (r *sheetCanvasRenderer) drawClampZones(scale, panX, panY float32) {
+	for _, cz := range r.sc.settings.ClampZones {
+		cx := float32(cz.X)*scale + panX
+		cy := float32(cz.Y)*scale + panY
+		cw := float32(cz.Width) * scale
+		ch := float32(cz.Height) * scale
+
+		// Clamp zone background (orange warning color, distinct from red tab zones)
+		czRect := canvas.NewRectangle(color.NRGBA{R: 255, G: 165, B: 0, A: 140})
+		czRect.Resize(fyne.NewSize(cw, ch))
+		czRect.Move(fyne.NewPos(cx, cy))
+		r.objects = append(r.objects, czRect)
+
+		// Clamp zone border
+		czBorder := canvas.NewRectangle(color.Transparent)
+		czBorder.StrokeColor = color.NRGBA{R: 200, G: 120, B: 0, A: 255}
+		czBorder.StrokeWidth = 2
+		czBorder.Resize(fyne.NewSize(cw, ch))
+		czBorder.Move(fyne.NewPos(cx, cy))
+		r.objects = append(r.objects, czBorder)
+
+		// Label for larger zones
+		if cw > 35 && ch > 15 {
+			labelText := "CLAMP"
+			if cz.Label != "" {
+				labelText = cz.Label
+			}
+			clampLabel := canvas.NewText(labelText, color.White)
+			clampLabel.TextSize = 8
+			clampLabel.TextStyle = fyne.TextStyle{Bold: true}
+			clampLabel.Move(fyne.NewPos(cx+3, cy+2))
+			r.objects = append(r.objects, clampLabel)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `ClampZone` type to model with label, position, dimensions, and Z-height for collision detection
- Optimizer excludes clamp zones from placement area (works with both guillotine and genetic algorithms)
- Clamp zones visualized on SheetCanvas in orange with labels
- Settings panel UI for adding/removing clamp zones with preset positions for common clamp layouts

## Test plan
- [x] Unit tests for `ClampZone.Overlaps()` and `ClampZone.ToTabZone()`
- [x] Optimizer test: parts avoid clamp zone exclusion areas
- [x] Optimizer test: clamp zones that cover most of sheet cause parts to be unplaced
- [x] Optimizer test: multiple clamp zones in corners still allow center placement
- [x] Optimizer test: no clamp zones works as before
- [x] All existing tests pass
- [x] Build compiles successfully

Resolves #31