### PR TITLE
[Feature] Add QR code label generation for cut parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Excel Import** — Read .xlsx files with auto header detection
 - **DXF Import** — Import non-rectangular parts from DXF files (LWPOLYLINE, LINE, ARC, CIRCLE)
 - **PDF Export** — Multi-page cut diagrams with dimensions, labels, efficiency stats, and summary
+- **QR Label Export** — Generate printable QR-coded labels for cut parts with part name, dimensions, and sheet position (Avery 5160 layout)
 - **GCode Export** — Per-sheet GCode files with configurable profiles
 - **Project Save/Load** — JSON-based project files (`.cnccalc`)
 
@@ -115,7 +116,8 @@ SlabCut/
 │   │   ├── importer.go         # CSV/Excel import with auto-detection
 │   │   └── dxf.go              # DXF file import
 │   ├── export/
-│   │   └── pdf.go              # PDF export of cut diagrams
+│   │   ├── pdf.go              # PDF export of cut diagrams
+│   │   └── labels.go           # QR code label generation
 │   ├── project/
 │   │   ├── project.go          # Save/load project files
 │   │   ├── profiles.go         # Custom GCode profile persistence

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.4 // indirect
 	github.com/rymdport/portal v0.3.0 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef // indirect
 	github.com/tiendc/go-deepcopy v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/internal/export/labels.go
+++ b/internal/export/labels.go
@@ -1,0 +1,189 @@
+// Package export provides functionality for exporting cut optimization results
+// to various file formats including QR-coded part labels.
+package export
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-pdf/fpdf"
+	"github.com/piwi3910/SlabCut/internal/model"
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+// LabelInfo holds the data encoded into each part label's QR code.
+type LabelInfo struct {
+	PartLabel  string  `json:"label"`
+	Width      float64 `json:"width_mm"`
+	Height     float64 `json:"height_mm"`
+	SheetIndex int     `json:"sheet"`
+	SheetLabel string  `json:"sheet_label"`
+	Rotated    bool    `json:"rotated"`
+	X          float64 `json:"x_mm"`
+	Y          float64 `json:"y_mm"`
+}
+
+// Label layout constants for Avery 5160-compatible labels (3 columns, 10 rows per page).
+// Each label cell is approximately 66.7mm x 25.4mm on US Letter paper.
+const (
+	labelPageWidth  = 215.9 // US Letter width in mm
+	labelPageHeight = 279.4 // US Letter height in mm
+	labelMarginTop  = 12.7  // mm
+	labelMarginLeft = 4.8   // mm
+	labelWidth      = 66.7  // mm per label
+	labelHeight     = 25.4  // mm per label
+	labelCols       = 3
+	labelRows       = 10
+	labelsPerPage   = labelCols * labelRows
+	qrSize          = 20.0 // QR code size in mm
+	labelPadding    = 2.0  // mm internal padding
+)
+
+// ExportLabels generates a PDF of QR-coded labels for all placed parts.
+// Each label contains the part name, dimensions, and a QR code encoding
+// part metadata as JSON. Labels are laid out on a standard label sheet
+// format (Avery 5160 / 3 columns x 10 rows on US Letter).
+func ExportLabels(path string, result model.OptimizeResult) error {
+	if len(result.Sheets) == 0 {
+		return fmt.Errorf("no sheets to generate labels for")
+	}
+
+	// Collect all placed parts across all sheets
+	var labels []LabelInfo
+	for sheetIdx, sheet := range result.Sheets {
+		for _, p := range sheet.Placements {
+			labels = append(labels, LabelInfo{
+				PartLabel:  p.Part.Label,
+				Width:      p.Part.Width,
+				Height:     p.Part.Height,
+				SheetIndex: sheetIdx + 1,
+				SheetLabel: sheet.Stock.Label,
+				Rotated:    p.Rotated,
+				X:          p.X,
+				Y:          p.Y,
+			})
+		}
+	}
+
+	if len(labels) == 0 {
+		return fmt.Errorf("no parts placed to generate labels for")
+	}
+
+	pdf := fpdf.New("P", "mm", "Letter", "")
+	pdf.SetAutoPageBreak(false, 0)
+
+	for i, label := range labels {
+		// Add new page when needed
+		if i%labelsPerPage == 0 {
+			pdf.AddPage()
+		}
+
+		posOnPage := i % labelsPerPage
+		col := posOnPage % labelCols
+		row := posOnPage / labelCols
+
+		x := labelMarginLeft + float64(col)*labelWidth
+		y := labelMarginTop + float64(row)*labelHeight
+
+		if err := renderLabel(pdf, x, y, label); err != nil {
+			return fmt.Errorf("failed to render label for %q: %w", label.PartLabel, err)
+		}
+	}
+
+	return pdf.OutputFileAndClose(path)
+}
+
+// renderLabel draws a single label at the given position.
+func renderLabel(pdf *fpdf.Fpdf, x, y float64, info LabelInfo) error {
+	// Draw light border for cutting guide
+	pdf.SetDrawColor(200, 200, 200)
+	pdf.SetLineWidth(0.1)
+	pdf.Rect(x, y, labelWidth, labelHeight, "D")
+
+	// Generate QR code PNG bytes
+	qrData, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("failed to marshal label info: %w", err)
+	}
+
+	qrPNG, err := qrcode.Encode(string(qrData), qrcode.Medium, 256)
+	if err != nil {
+		return fmt.Errorf("failed to generate QR code: %w", err)
+	}
+
+	// Register QR image with a unique name
+	imgName := fmt.Sprintf("qr_%s_%d_%d", info.PartLabel, info.SheetIndex, int(info.X*1000+info.Y))
+	pdf.RegisterImageOptionsReader(imgName, fpdf.ImageOptions{ImageType: "PNG"}, bytes.NewReader(qrPNG))
+
+	// Place QR code on the right side of the label
+	qrX := x + labelWidth - qrSize - labelPadding
+	qrY := y + (labelHeight-qrSize)/2
+	pdf.ImageOptions(imgName, qrX, qrY, qrSize, qrSize, false, fpdf.ImageOptions{ImageType: "PNG"}, 0, "")
+
+	// Text area (left side of label)
+	textX := x + labelPadding
+	textW := labelWidth - qrSize - 3*labelPadding
+
+	// Part label (bold, larger)
+	pdf.SetFont("Helvetica", "B", 9)
+	pdf.SetTextColor(0, 0, 0)
+	pdf.SetXY(textX, y+labelPadding)
+
+	// Truncate label if too long
+	partLabel := info.PartLabel
+	if pdf.GetStringWidth(partLabel) > textW {
+		for len(partLabel) > 0 && pdf.GetStringWidth(partLabel+"...") > textW {
+			partLabel = partLabel[:len(partLabel)-1]
+		}
+		partLabel += "..."
+	}
+	pdf.CellFormat(textW, 4.5, partLabel, "", 1, "L", false, 0, "")
+
+	// Dimensions
+	pdf.SetFont("Helvetica", "", 7)
+	pdf.SetXY(textX, y+labelPadding+5)
+	dims := fmt.Sprintf("%.0f x %.0f mm", info.Width, info.Height)
+	pdf.CellFormat(textW, 3.5, dims, "", 1, "L", false, 0, "")
+
+	// Sheet and position info
+	pdf.SetFont("Helvetica", "", 6)
+	pdf.SetTextColor(100, 100, 100)
+	pdf.SetXY(textX, y+labelPadding+9)
+	sheetInfo := fmt.Sprintf("Sheet %d @ (%.0f, %.0f)", info.SheetIndex, info.X, info.Y)
+	pdf.CellFormat(textW, 3, sheetInfo, "", 1, "L", false, 0, "")
+
+	// Rotation indicator
+	if info.Rotated {
+		pdf.SetXY(textX, y+labelPadding+12.5)
+		pdf.SetFont("Helvetica", "I", 6)
+		pdf.SetTextColor(150, 100, 0)
+		pdf.CellFormat(textW, 3, "Rotated 90\xb0", "", 0, "L", false, 0, "")
+	}
+
+	// Reset text color
+	pdf.SetTextColor(0, 0, 0)
+
+	return nil
+}
+
+// CollectLabelInfos extracts label information from an optimization result
+// for use in testing or alternative export formats.
+func CollectLabelInfos(result model.OptimizeResult) []LabelInfo {
+	var labels []LabelInfo
+	for sheetIdx, sheet := range result.Sheets {
+		for _, p := range sheet.Placements {
+			labels = append(labels, LabelInfo{
+				PartLabel:  p.Part.Label,
+				Width:      p.Part.Width,
+				Height:     p.Part.Height,
+				SheetIndex: sheetIdx + 1,
+				SheetLabel: sheet.Stock.Label,
+				Rotated:    p.Rotated,
+				X:          p.X,
+				Y:          p.Y,
+			})
+		}
+	}
+	return labels
+}

--- a/internal/export/labels_test.go
+++ b/internal/export/labels_test.go
@@ -1,0 +1,211 @@
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+func buildLabelsTestResult() model.OptimizeResult {
+	return model.OptimizeResult{
+		Sheets: []model.SheetResult{
+			{
+				Stock: model.StockSheet{
+					ID:    "s1",
+					Label: "Plywood 2440x1220",
+					Width: 2440, Height: 1220, Quantity: 1,
+					Tabs: model.StockTabConfig{Enabled: false},
+				},
+				Placements: []model.Placement{
+					{
+						Part:    model.Part{ID: "p1", Label: "Side Panel", Width: 600, Height: 400, Quantity: 1},
+						X:       10, Y: 10, Rotated: false,
+					},
+					{
+						Part:    model.Part{ID: "p2", Label: "Top", Width: 500, Height: 300, Quantity: 1},
+						X:       620, Y: 10, Rotated: true,
+					},
+				},
+			},
+			{
+				Stock: model.StockSheet{
+					ID:    "s2",
+					Label: "MDF 1200x600",
+					Width: 1200, Height: 600, Quantity: 1,
+					Tabs: model.StockTabConfig{Enabled: false},
+				},
+				Placements: []model.Placement{
+					{
+						Part:    model.Part{ID: "p3", Label: "Back Panel", Width: 800, Height: 500, Quantity: 1},
+						X:       10, Y: 10, Rotated: false,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestExportLabels_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "labels.pdf")
+
+	result := buildLabelsTestResult()
+	err := ExportLabels(path, result)
+	if err != nil {
+		t.Fatalf("ExportLabels returned error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("PDF file was not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("PDF file is empty")
+	}
+	if info.Size() < 500 {
+		t.Errorf("PDF file seems too small: %d bytes", info.Size())
+	}
+}
+
+func TestExportLabels_EmptyResult(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.pdf")
+
+	result := model.OptimizeResult{Sheets: nil}
+	err := ExportLabels(path, result)
+	if err == nil {
+		t.Fatal("expected error for empty result, got nil")
+	}
+}
+
+func TestExportLabels_NoPlacements(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "no_placements.pdf")
+
+	result := model.OptimizeResult{
+		Sheets: []model.SheetResult{
+			{
+				Stock: model.StockSheet{ID: "s1", Label: "Board", Width: 1000, Height: 500, Quantity: 1},
+			},
+		},
+	}
+	err := ExportLabels(path, result)
+	if err == nil {
+		t.Fatal("expected error for result with no placements, got nil")
+	}
+}
+
+func TestCollectLabelInfos(t *testing.T) {
+	result := buildLabelsTestResult()
+	labels := CollectLabelInfos(result)
+
+	if len(labels) != 3 {
+		t.Fatalf("expected 3 labels, got %d", len(labels))
+	}
+
+	// Check first label
+	if labels[0].PartLabel != "Side Panel" {
+		t.Errorf("expected first label to be 'Side Panel', got %q", labels[0].PartLabel)
+	}
+	if labels[0].Width != 600 || labels[0].Height != 400 {
+		t.Errorf("wrong dimensions: got %.0fx%.0f, want 600x400", labels[0].Width, labels[0].Height)
+	}
+	if labels[0].SheetIndex != 1 {
+		t.Errorf("expected sheet index 1, got %d", labels[0].SheetIndex)
+	}
+	if labels[0].Rotated {
+		t.Error("expected first label not rotated")
+	}
+
+	// Check second label (rotated)
+	if !labels[1].Rotated {
+		t.Error("expected second label to be rotated")
+	}
+
+	// Check third label (second sheet)
+	if labels[2].SheetIndex != 2 {
+		t.Errorf("expected sheet index 2 for third label, got %d", labels[2].SheetIndex)
+	}
+}
+
+func TestLabelInfo_JSONRoundTrip(t *testing.T) {
+	info := LabelInfo{
+		PartLabel:  "Test Part",
+		Width:      300,
+		Height:     200,
+		SheetIndex: 1,
+		SheetLabel: "Plywood",
+		Rotated:    true,
+		X:          50,
+		Y:          100,
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var decoded LabelInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if decoded.PartLabel != info.PartLabel {
+		t.Errorf("label mismatch: got %q, want %q", decoded.PartLabel, info.PartLabel)
+	}
+	if decoded.Width != info.Width || decoded.Height != info.Height {
+		t.Errorf("dimensions mismatch: got %.0fx%.0f, want %.0fx%.0f",
+			decoded.Width, decoded.Height, info.Width, info.Height)
+	}
+	if decoded.Rotated != info.Rotated {
+		t.Error("rotated flag mismatch")
+	}
+}
+
+func TestExportLabels_ManyParts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "many_labels.pdf")
+
+	// Create 35 placements to test multi-page label generation
+	placements := make([]model.Placement, 35)
+	for i := range placements {
+		placements[i] = model.Placement{
+			Part: model.Part{
+				ID:       "p" + string(rune('A'+i%26)),
+				Label:    "Part " + string(rune('A'+i%26)),
+				Width:    100 + float64(i*10),
+				Height:   50 + float64(i*5),
+				Quantity: 1,
+			},
+			X: float64(i * 110), Y: 10,
+		}
+	}
+
+	result := model.OptimizeResult{
+		Sheets: []model.SheetResult{
+			{
+				Stock: model.StockSheet{
+					ID: "s1", Label: "Large Board", Width: 5000, Height: 3000, Quantity: 1,
+					Tabs: model.StockTabConfig{Enabled: false},
+				},
+				Placements: placements,
+			},
+		},
+	}
+
+	err := ExportLabels(path, result)
+	if err != nil {
+		t.Fatalf("ExportLabels returned error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("PDF file was not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("PDF file is empty")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -942,7 +942,10 @@ func (a *App) refreshResults() {
 	saveOffcutsBtn := widget.NewButtonWithIcon("Save Offcuts to Inventory", theme.ContentAddIcon(), func() {
 		a.saveOffcutsToInventory()
 	})
-	toolbar := container.NewHBox(layout.NewSpacer(), saveOffcutsBtn, simulateBtn, exportBtn)
+	labelsBtn := widget.NewButtonWithIcon("Generate Labels", theme.ListIcon(), func() {
+		a.exportLabels()
+	})
+	toolbar := container.NewHBox(layout.NewSpacer(), saveOffcutsBtn, labelsBtn, simulateBtn, exportBtn)
 
 	// Build both cut layout and inline simulation views
 	sheetResults := widgets.RenderSheetResults(a.project.Result, a.project.Settings, a.project.Parts)
@@ -1287,6 +1290,29 @@ func (a *App) exportPDF() {
 		}
 	}, a.window)
 	d.SetFileName("cut-layout.pdf")
+	d.Show()
+}
+
+func (a *App) exportLabels() {
+	if a.project.Result == nil || len(a.project.Result.Sheets) == 0 {
+		dialog.ShowInformation("No results", "Run the optimizer first before generating labels.", a.window)
+		return
+	}
+
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		if err != nil || writer == nil {
+			return
+		}
+		writer.Close()
+		path := writer.URI().Path()
+		if exportErr := export.ExportLabels(path, *a.project.Result); exportErr != nil {
+			dialog.ShowError(exportErr, a.window)
+		} else {
+			dialog.ShowInformation("Export Complete",
+				fmt.Sprintf("QR code labels saved to %s", path), a.window)
+		}
+	}, a.window)
+	d.SetFileName("part-labels.pdf")
 	d.Show()
 }
 


### PR DESCRIPTION
## Summary
- Add QR code label PDF export for all placed parts in optimization results
- Each label contains part name, dimensions, sheet/position info, and a QR code encoding full metadata as JSON
- Labels use Avery 5160 layout (3 columns x 10 rows on US Letter) for standard label sheet printing
- New "Generate Labels" button added to the results panel toolbar

## Test plan
- [x] Unit tests for label generation, empty results, many-part pagination
- [x] JSON round-trip test for QR code data integrity
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/slabcut`)

Resolves #75