### PR TITLE
[Feature] Add automatic what-if comparison for optimization settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Offcuts / Remnants Tracking** — Automatically detects usable rectangular remnants after optimization; save offcuts to stock inventory for future projects
 - **Purchasing Calculator** — Calculate sheets needed, board feet, and estimated cost with configurable waste factor (Tools menu)
 - **Edge Banding Calculator** — Mark which edges need banding per part (T/B/L/R); view per-part and total banding length with waste factor in results
+- **What-If Comparison** — Compare multiple optimization scenarios side by side (algorithm, kerf, edge trim) and apply the best result
 - **Admin Menu** — Application settings, inventory management, data backup/restore
 - **Stock Size Presets** — Quick-select dropdown with common panel sizes (Full, Half, Quarter sheet, Euro sizes)
 

--- a/internal/engine/compare.go
+++ b/internal/engine/compare.go
@@ -1,0 +1,103 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// ComparisonScenario defines a named set of settings to compare.
+type ComparisonScenario struct {
+	Name     string
+	Settings model.CutSettings
+}
+
+// ComparisonResult holds the optimization result and computed statistics
+// for a single scenario.
+type ComparisonResult struct {
+	Scenario    ComparisonScenario
+	Result      model.OptimizeResult
+	SheetsUsed  int
+	TotalCuts   int
+	WastePercent float64
+	UnplacedCount int
+}
+
+// CompareScenarios runs optimization for each scenario and returns the results
+// sorted by scenario order. This enables side-by-side comparison of different
+// optimization parameters (e.g., different algorithms, kerf widths, etc.).
+func CompareScenarios(scenarios []ComparisonScenario, parts []model.Part, stocks []model.StockSheet) []ComparisonResult {
+	results := make([]ComparisonResult, 0, len(scenarios))
+
+	for _, scenario := range scenarios {
+		opt := New(scenario.Settings)
+		result := opt.Optimize(parts, stocks)
+
+		totalCuts := 0
+		for _, sheet := range result.Sheets {
+			totalCuts += len(sheet.Placements)
+		}
+
+		wastePercent := 100.0 - result.TotalEfficiency()
+
+		results = append(results, ComparisonResult{
+			Scenario:      scenario,
+			Result:        result,
+			SheetsUsed:    len(result.Sheets),
+			TotalCuts:     totalCuts,
+			WastePercent:  wastePercent,
+			UnplacedCount: len(result.UnplacedParts),
+		})
+	}
+
+	return results
+}
+
+// BuildDefaultScenarios generates a set of comparison scenarios based on
+// the current settings, varying key parameters to show what-if alternatives.
+func BuildDefaultScenarios(baseSettings model.CutSettings) []ComparisonScenario {
+	scenarios := []ComparisonScenario{
+		{
+			Name:     "Current Settings",
+			Settings: baseSettings,
+		},
+	}
+
+	// Scenario: Try the other algorithm
+	altAlgo := baseSettings
+	if baseSettings.Algorithm == model.AlgorithmGuillotine {
+		altAlgo.Algorithm = model.AlgorithmGenetic
+		scenarios = append(scenarios, ComparisonScenario{
+			Name:     "Genetic Algorithm",
+			Settings: altAlgo,
+		})
+	} else {
+		altAlgo.Algorithm = model.AlgorithmGuillotine
+		scenarios = append(scenarios, ComparisonScenario{
+			Name:     "Guillotine Algorithm",
+			Settings: altAlgo,
+		})
+	}
+
+	// Scenario: Tighter kerf (simulate thinner blade)
+	if baseSettings.KerfWidth > 1.0 {
+		tightKerf := baseSettings
+		tightKerf.KerfWidth = baseSettings.KerfWidth * 0.5
+		scenarios = append(scenarios, ComparisonScenario{
+			Name:     fmt.Sprintf("Kerf %.1fmm (half)", tightKerf.KerfWidth),
+			Settings: tightKerf,
+		})
+	}
+
+	// Scenario: No edge trim
+	if baseSettings.EdgeTrim > 0 {
+		noTrim := baseSettings
+		noTrim.EdgeTrim = 0
+		scenarios = append(scenarios, ComparisonScenario{
+			Name:     "No Edge Trim",
+			Settings: noTrim,
+		})
+	}
+
+	return scenarios
+}

--- a/internal/engine/compare_test.go
+++ b/internal/engine/compare_test.go
@@ -1,0 +1,123 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+func TestCompareScenarios_Basic(t *testing.T) {
+	parts := []model.Part{
+		{ID: "p1", Label: "A", Width: 400, Height: 300, Quantity: 2, Grain: model.GrainNone},
+		{ID: "p2", Label: "B", Width: 200, Height: 150, Quantity: 3, Grain: model.GrainNone},
+	}
+	stocks := []model.StockSheet{
+		{ID: "s1", Label: "Board", Width: 2440, Height: 1220, Quantity: 2},
+	}
+
+	base := model.DefaultSettings()
+	scenarios := []ComparisonScenario{
+		{Name: "Guillotine", Settings: base},
+		{Name: "Genetic", Settings: func() model.CutSettings {
+			s := base
+			s.Algorithm = model.AlgorithmGenetic
+			return s
+		}()},
+	}
+
+	results := CompareScenarios(scenarios, parts, stocks)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	for i, r := range results {
+		if r.Scenario.Name != scenarios[i].Name {
+			t.Errorf("result %d: name mismatch: got %q, want %q", i, r.Scenario.Name, scenarios[i].Name)
+		}
+		if r.SheetsUsed == 0 {
+			t.Errorf("result %d: expected at least one sheet used", i)
+		}
+		if r.TotalCuts == 0 {
+			t.Errorf("result %d: expected at least one cut", i)
+		}
+		if r.WastePercent < 0 || r.WastePercent > 100 {
+			t.Errorf("result %d: waste percent out of range: %.1f", i, r.WastePercent)
+		}
+	}
+}
+
+func TestCompareScenarios_Empty(t *testing.T) {
+	results := CompareScenarios(nil, nil, nil)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for nil scenarios, got %d", len(results))
+	}
+}
+
+func TestBuildDefaultScenarios_Guillotine(t *testing.T) {
+	base := model.DefaultSettings()
+	base.Algorithm = model.AlgorithmGuillotine
+
+	scenarios := BuildDefaultScenarios(base)
+
+	if len(scenarios) < 2 {
+		t.Fatalf("expected at least 2 scenarios, got %d", len(scenarios))
+	}
+
+	if scenarios[0].Name != "Current Settings" {
+		t.Errorf("first scenario should be 'Current Settings', got %q", scenarios[0].Name)
+	}
+
+	// Should include Genetic Algorithm as alternative
+	found := false
+	for _, s := range scenarios {
+		if s.Name == "Genetic Algorithm" {
+			found = true
+			if s.Settings.Algorithm != model.AlgorithmGenetic {
+				t.Error("Genetic Algorithm scenario should use genetic algorithm")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a 'Genetic Algorithm' scenario")
+	}
+}
+
+func TestBuildDefaultScenarios_Genetic(t *testing.T) {
+	base := model.DefaultSettings()
+	base.Algorithm = model.AlgorithmGenetic
+
+	scenarios := BuildDefaultScenarios(base)
+
+	found := false
+	for _, s := range scenarios {
+		if s.Name == "Guillotine Algorithm" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a 'Guillotine Algorithm' scenario when base is genetic")
+	}
+}
+
+func TestCompareScenarios_UnplacedParts(t *testing.T) {
+	// Parts that are too large for the stock
+	parts := []model.Part{
+		{ID: "p1", Label: "Huge", Width: 5000, Height: 5000, Quantity: 1, Grain: model.GrainNone},
+	}
+	stocks := []model.StockSheet{
+		{ID: "s1", Label: "Small", Width: 100, Height: 100, Quantity: 1},
+	}
+
+	scenarios := []ComparisonScenario{
+		{Name: "Test", Settings: model.DefaultSettings()},
+	}
+
+	results := CompareScenarios(scenarios, parts, stocks)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].UnplacedCount != 1 {
+		t.Errorf("expected 1 unplaced part, got %d", results[0].UnplacedCount)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -185,6 +185,9 @@ func (a *App) SetupMenus() {
 			a.runOptimize()
 			a.tabs.SelectIndex(3) // Switch to Results tab
 		}),
+		fyne.NewMenuItem("Compare Settings...", func() {
+			a.showCompareDialog()
+		}),
 		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Purchasing Calculator...", func() {
 			a.showPurchasingCalculator()

--- a/internal/ui/compare.go
+++ b/internal/ui/compare.go
@@ -1,0 +1,172 @@
+package ui
+
+import (
+	"fmt"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/piwi3910/SlabCut/internal/engine"
+)
+
+// showCompareDialog runs optimization with multiple parameter scenarios and
+// displays the results in a comparison table so the user can pick the best one.
+func (a *App) showCompareDialog() {
+	if len(a.project.Parts) == 0 {
+		dialog.ShowInformation("Nothing to compare", "Add at least one part first.", a.window)
+		return
+	}
+	if len(a.project.Stocks) == 0 {
+		dialog.ShowInformation("No stock sheets", "Add at least one stock sheet first.", a.window)
+		return
+	}
+
+	scenarios := engine.BuildDefaultScenarios(a.project.Settings)
+
+	// Add a custom kerf scenario based on user input
+	customKerfEntry := widget.NewEntry()
+	customKerfEntry.SetPlaceHolder("e.g. 2.0")
+	customKerfEntry.SetText(fmt.Sprintf("%.1f", a.project.Settings.KerfWidth*0.75))
+
+	// Build custom scenarios form
+	addCustomKerf := widget.NewCheck("Add custom kerf scenario", nil)
+
+	customTrimEntry := widget.NewEntry()
+	customTrimEntry.SetPlaceHolder("e.g. 5.0")
+	customTrimEntry.SetText(fmt.Sprintf("%.1f", a.project.Settings.EdgeTrim*0.5))
+	addCustomTrim := widget.NewCheck("Add custom edge trim scenario", nil)
+
+	configForm := dialog.NewForm("Configure Comparison", "Run Comparison", "Cancel",
+		[]*widget.FormItem{
+			widget.NewFormItem("", widget.NewLabel(
+				fmt.Sprintf("This will run %d+ optimization scenarios and compare results.", len(scenarios)),
+			)),
+			widget.NewFormItem("Custom Kerf (mm)", container.NewBorder(nil, nil, addCustomKerf, nil, customKerfEntry)),
+			widget.NewFormItem("Custom Trim (mm)", container.NewBorder(nil, nil, addCustomTrim, nil, customTrimEntry)),
+		},
+		func(ok bool) {
+			if !ok {
+				return
+			}
+
+			// Add custom scenarios if checked
+			if addCustomKerf.Checked {
+				var kerfVal float64
+				if _, err := fmt.Sscanf(customKerfEntry.Text, "%f", &kerfVal); err == nil && kerfVal >= 0 {
+					s := a.project.Settings
+					s.KerfWidth = kerfVal
+					scenarios = append(scenarios, engine.ComparisonScenario{
+						Name:     fmt.Sprintf("Kerf %.1fmm (custom)", kerfVal),
+						Settings: s,
+					})
+				}
+			}
+			if addCustomTrim.Checked {
+				var trimVal float64
+				if _, err := fmt.Sscanf(customTrimEntry.Text, "%f", &trimVal); err == nil && trimVal >= 0 {
+					s := a.project.Settings
+					s.EdgeTrim = trimVal
+					scenarios = append(scenarios, engine.ComparisonScenario{
+						Name:     fmt.Sprintf("Trim %.1fmm (custom)", trimVal),
+						Settings: s,
+					})
+				}
+			}
+
+			a.runComparison(scenarios)
+		},
+		a.window,
+	)
+	configForm.Resize(fyne.NewSize(500, 300))
+	configForm.Show()
+}
+
+// runComparison executes the comparison and shows results.
+func (a *App) runComparison(scenarios []engine.ComparisonScenario) {
+	results := engine.CompareScenarios(scenarios, a.project.Parts, a.project.Stocks)
+
+	if len(results) == 0 {
+		dialog.ShowInformation("No Results", "No comparison results were generated.", a.window)
+		return
+	}
+
+	a.showComparisonResults(results)
+}
+
+// showComparisonResults displays comparison results in a table with an "Apply" button
+// for the user to keep a specific result.
+func (a *App) showComparisonResults(results []engine.ComparisonResult) {
+	// Build table header
+	cols := 6
+	header := container.NewGridWithColumns(cols,
+		widget.NewLabelWithStyle("Scenario", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Sheets", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Cuts", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Waste %", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Unplaced", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Action", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+	)
+
+	rows := container.NewVBox(header, widget.NewSeparator())
+
+	// Find the best result (lowest waste with all parts placed)
+	bestIdx := 0
+	bestScore := -1.0
+	for i, r := range results {
+		score := 100.0 - r.WastePercent
+		if r.UnplacedCount == 0 && score > bestScore {
+			bestScore = score
+			bestIdx = i
+		}
+	}
+
+	for i, r := range results {
+		idx := i
+		result := r
+
+		nameLabel := widget.NewLabel(r.Scenario.Name)
+		if idx == bestIdx {
+			nameLabel = widget.NewLabelWithStyle(r.Scenario.Name+" *", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+		}
+
+		applyBtn := widget.NewButton("Apply", func() {
+			a.saveState("Apply Comparison Result")
+			a.project.Settings = result.Scenario.Settings
+			a.project.Result = &result.Result
+			a.refreshResults()
+			dialog.ShowInformation("Applied",
+				fmt.Sprintf("Applied settings from scenario %q.\nEfficiency: %.1f%%",
+					result.Scenario.Name, 100.0-result.WastePercent),
+				a.window)
+		})
+
+		wasteLabel := fmt.Sprintf("%.1f%%", r.WastePercent)
+		unplacedLabel := fmt.Sprintf("%d", r.UnplacedCount)
+		if r.UnplacedCount > 0 {
+			unplacedLabel += " !"
+		}
+
+		row := container.NewGridWithColumns(cols,
+			nameLabel,
+			widget.NewLabel(fmt.Sprintf("%d", r.SheetsUsed)),
+			widget.NewLabel(fmt.Sprintf("%d", r.TotalCuts)),
+			widget.NewLabel(wasteLabel),
+			widget.NewLabel(unplacedLabel),
+			applyBtn,
+		)
+		rows.Add(row)
+	}
+
+	// Add legend
+	rows.Add(widget.NewSeparator())
+	rows.Add(widget.NewLabelWithStyle("* = Best result (lowest waste with all parts placed)", fyne.TextAlignLeading, fyne.TextStyle{Italic: true}))
+
+	scrollable := container.NewVScroll(rows)
+	scrollable.SetMinSize(fyne.NewSize(650, 300))
+
+	d := dialog.NewCustom("Optimization Comparison", "Close", scrollable, a.window)
+	d.Resize(fyne.NewSize(700, 400))
+	d.Show()
+}


### PR DESCRIPTION
## Summary
- Add what-if comparison feature to Tools menu for running multiple optimization scenarios
- Engine generates default scenarios (algorithm swap, half kerf, no edge trim) plus user-defined custom kerf/trim values
- Results displayed in comparison table showing sheets used, waste%, cuts, unplaced parts
- User can apply any scenario's result with a single click, updating both settings and optimization result

## Test plan
- [x] Unit tests for CompareScenarios and BuildDefaultScenarios
- [x] Tests for empty input, unplaced parts edge case
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/slabcut`)

Resolves #76