### PR TITLE
[Feature] Add multi-material optimization with per-material grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Saw Kerf & Edge Trim** — Accounts for blade width and stock edge waste
 - **Part Rotation** — Automatically rotates parts for better fit (respects grain)
 - **Multiple Stock Sizes** — Use different stock sheet sizes in one run with smart selection (trial-packing heuristic)
+- **Multi-Material Optimization** — Assign material types (e.g., Plywood, MDF) to parts and stock sheets; optimizer groups by material so parts are only placed on matching stocks
 - **Fixture / Clamp Zones** — Define rectangular exclusion zones for clamps and fixtures; optimizer avoids placing parts in these areas
 
 ### CNC & GCode

--- a/internal/engine/optimizer_test.go
+++ b/internal/engine/optimizer_test.go
@@ -482,3 +482,174 @@ func TestOptimize_NoClampZones(t *testing.T) {
 	assert.Len(t, result.UnplacedParts, 0)
 	assert.Len(t, result.Sheets, 1)
 }
+
+// ─── Multi-Material Optimization Tests ─────────────────────────────
+
+func TestGroupByMaterial_NoMaterials(t *testing.T) {
+	parts := []model.Part{
+		model.NewPart("A", 500, 300, 1),
+		model.NewPart("B", 400, 200, 1),
+	}
+	stocks := []model.StockSheet{
+		model.NewStockSheet("Sheet1", 1000, 600, 1),
+	}
+
+	groups := groupByMaterial(parts, stocks)
+
+	require.Len(t, groups, 1, "should be single group when no materials")
+	assert.Len(t, groups[0].parts, 2)
+	assert.Len(t, groups[0].stocks, 1)
+}
+
+func TestGroupByMaterial_SingleMaterial(t *testing.T) {
+	partA := model.NewPart("A", 500, 300, 1)
+	partA.Material = "Plywood"
+	partB := model.NewPart("B", 400, 200, 1)
+	partB.Material = "Plywood"
+
+	stockPly := model.NewStockSheet("Ply", 1000, 600, 1)
+	stockPly.Material = "Plywood"
+
+	groups := groupByMaterial([]model.Part{partA, partB}, []model.StockSheet{stockPly})
+
+	require.Len(t, groups, 1, "single material should produce one group")
+	assert.Len(t, groups[0].parts, 2)
+	assert.Len(t, groups[0].stocks, 1)
+	assert.Equal(t, "Plywood", groups[0].material)
+}
+
+func TestGroupByMaterial_MultipleMaterials(t *testing.T) {
+	partPly := model.NewPart("PlyPart", 500, 300, 1)
+	partPly.Material = "Plywood"
+	partMDF := model.NewPart("MDFPart", 400, 200, 1)
+	partMDF.Material = "MDF"
+
+	stockPly := model.NewStockSheet("PlySheet", 1000, 600, 1)
+	stockPly.Material = "Plywood"
+	stockMDF := model.NewStockSheet("MDFSheet", 1000, 600, 1)
+	stockMDF.Material = "MDF"
+
+	groups := groupByMaterial(
+		[]model.Part{partPly, partMDF},
+		[]model.StockSheet{stockPly, stockMDF},
+	)
+
+	require.Len(t, groups, 2, "two materials should produce two groups")
+
+	assert.Equal(t, "MDF", groups[0].material)
+	assert.Len(t, groups[0].parts, 1)
+	assert.Equal(t, "MDFPart", groups[0].parts[0].Label)
+
+	assert.Equal(t, "Plywood", groups[1].material)
+	assert.Len(t, groups[1].parts, 1)
+	assert.Equal(t, "PlyPart", groups[1].parts[0].Label)
+}
+
+func TestGroupByMaterial_UniversalParts(t *testing.T) {
+	partUniversal := model.NewPart("Universal", 500, 300, 1)
+	partPly := model.NewPart("PlyPart", 400, 200, 1)
+	partPly.Material = "Plywood"
+
+	stockPly := model.NewStockSheet("PlySheet", 1000, 600, 2)
+	stockPly.Material = "Plywood"
+
+	groups := groupByMaterial(
+		[]model.Part{partUniversal, partPly},
+		[]model.StockSheet{stockPly},
+	)
+
+	require.Len(t, groups, 2)
+	assert.Equal(t, "Plywood", groups[0].material)
+	assert.Len(t, groups[0].parts, 1)
+	assert.Equal(t, "PlyPart", groups[0].parts[0].Label)
+
+	assert.Len(t, groups[1].parts, 1)
+	assert.Equal(t, "Universal", groups[1].parts[0].Label)
+}
+
+func TestGroupByMaterial_UniversalStocks(t *testing.T) {
+	partPly := model.NewPart("PlyPart", 500, 300, 1)
+	partPly.Material = "Plywood"
+	partMDF := model.NewPart("MDFPart", 400, 200, 1)
+	partMDF.Material = "MDF"
+
+	stockUniversal := model.NewStockSheet("AnySheet", 1000, 600, 5)
+
+	groups := groupByMaterial(
+		[]model.Part{partPly, partMDF},
+		[]model.StockSheet{stockUniversal},
+	)
+
+	require.Len(t, groups, 2)
+	for _, g := range groups {
+		assert.GreaterOrEqual(t, len(g.stocks), 1,
+			"each material group should have the universal stock available")
+	}
+}
+
+func TestOptimize_MultiMaterial_SeparatePlacement(t *testing.T) {
+	opt := New(defaultTestSettings())
+
+	partPly := model.NewPart("PlyPart", 500, 300, 1)
+	partPly.Material = "Plywood"
+	partMDF := model.NewPart("MDFPart", 400, 200, 1)
+	partMDF.Material = "MDF"
+
+	stockPly := model.NewStockSheet("PlySheet", 1000, 600, 1)
+	stockPly.Material = "Plywood"
+	stockMDF := model.NewStockSheet("MDFSheet", 1000, 600, 1)
+	stockMDF.Material = "MDF"
+
+	result := opt.Optimize(
+		[]model.Part{partPly, partMDF},
+		[]model.StockSheet{stockPly, stockMDF},
+	)
+
+	require.Len(t, result.UnplacedParts, 0, "all parts should be placed")
+	require.Len(t, result.Sheets, 2, "each material should use its own sheet")
+
+	for _, sheet := range result.Sheets {
+		for _, p := range sheet.Placements {
+			if p.Part.Material != "" {
+				assert.Equal(t, p.Part.Material, sheet.Stock.Material,
+					"part material should match stock material")
+			}
+		}
+	}
+}
+
+func TestOptimize_MultiMaterial_WrongMaterialNotUsed(t *testing.T) {
+	opt := New(defaultTestSettings())
+
+	partPly := model.NewPart("PlyPart", 500, 300, 1)
+	partPly.Material = "Plywood"
+
+	stockMDF := model.NewStockSheet("MDFSheet", 1000, 600, 1)
+	stockMDF.Material = "MDF"
+
+	result := opt.Optimize(
+		[]model.Part{partPly},
+		[]model.StockSheet{stockMDF},
+	)
+
+	assert.Len(t, result.UnplacedParts, 1, "plywood part should not be placed on MDF stock")
+	assert.Len(t, result.Sheets, 0)
+}
+
+func TestOptimize_MultiMaterial_BackwardCompatible(t *testing.T) {
+	opt := New(defaultTestSettings())
+
+	parts := []model.Part{
+		model.NewPart("A", 500, 300, 1),
+		model.NewPart("B", 400, 200, 1),
+	}
+	stocks := []model.StockSheet{
+		model.NewStockSheet("Sheet", 1000, 600, 1),
+	}
+
+	result := opt.Optimize(parts, stocks)
+
+	require.Len(t, result.UnplacedParts, 0, "all parts should be placed")
+	require.Len(t, result.Sheets, 1)
+	assert.Len(t, result.Sheets[0].Placements, 2)
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -231,6 +231,7 @@ type Part struct {
 	Height      float64     `json:"height"` // mm (bounding box height for non-rectangular parts)
 	Quantity    int         `json:"quantity"`
 	Grain       Grain       `json:"grain"`
+	Material    string      `json:"material,omitempty"`     // Material type (e.g., "Plywood", "MDF"); empty means unspecified
 	Outline     Outline     `json:"outline,omitempty"`      // Non-rectangular part outline; nil for rectangular parts
 	EdgeBanding EdgeBanding `json:"edge_banding,omitempty"` // Which edges need banding
 }
@@ -254,6 +255,7 @@ type StockSheet struct {
 	Height        float64        `json:"height"` // mm
 	Quantity      int            `json:"quantity"`
 	Grain         Grain          `json:"grain"`           // Sheet grain direction (None, Horizontal, Vertical)
+	Material      string         `json:"material,omitempty"` // Material type (e.g., "Plywood", "MDF"); empty means unspecified
 	Tabs          StockTabConfig `json:"tabs"`            // Override default tab config for this sheet
 	PricePerSheet float64        `json:"price_per_sheet"` // Cost per sheet in user's currency (0 = not set)
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -348,12 +348,13 @@ func (a *App) refreshPartsList() {
 	}
 
 	// Header
-	header := container.NewGridWithColumns(9,
+	header := container.NewGridWithColumns(10,
 		widget.NewLabelWithStyle("Label", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Width (mm)", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Height (mm)", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Qty", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Grain", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Material", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Banding", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{}),
 		widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{}),
@@ -365,12 +366,17 @@ func (a *App) refreshPartsList() {
 	for i := range a.project.Parts {
 		idx := i // capture
 		p := a.project.Parts[idx]
-		row := container.NewGridWithColumns(9,
+		matLabel := "-"
+		if p.Material != "" {
+			matLabel = p.Material
+		}
+		row := container.NewGridWithColumns(10,
 			widget.NewLabel(p.Label),
 			widget.NewLabel(fmt.Sprintf("%.1f", p.Width)),
 			widget.NewLabel(fmt.Sprintf("%.1f", p.Height)),
 			widget.NewLabel(fmt.Sprintf("%d", p.Quantity)),
 			widget.NewLabel(p.Grain.String()),
+			widget.NewLabel(matLabel),
 			widget.NewLabel(p.EdgeBanding.String()),
 			widget.NewButtonWithIcon("", theme.DocumentCreateIcon(), func() {
 				a.showEditPartDialog(idx)
@@ -405,6 +411,9 @@ func (a *App) showAddPartDialog() {
 	grainSelect := widget.NewSelect([]string{"None", "Horizontal", "Vertical"}, nil)
 	grainSelect.SetSelected("None")
 
+	materialEntry := widget.NewEntry()
+	materialEntry.SetPlaceHolder("e.g., Plywood, MDF (optional)")
+
 	bandTop := widget.NewCheck("Top", nil)
 	bandBottom := widget.NewCheck("Bottom", nil)
 	bandLeft := widget.NewCheck("Left", nil)
@@ -418,6 +427,7 @@ func (a *App) showAddPartDialog() {
 			widget.NewFormItem("Height (mm)", heightEntry),
 			widget.NewFormItem("Quantity", qtyEntry),
 			widget.NewFormItem("Grain", grainSelect),
+			widget.NewFormItem("Material", materialEntry),
 			widget.NewFormItem("Edge Banding", bandingRow),
 		},
 		func(ok bool) {
@@ -439,6 +449,7 @@ func (a *App) showAddPartDialog() {
 			case "Vertical":
 				part.Grain = model.GrainVertical
 			}
+			part.Material = strings.TrimSpace(materialEntry.Text)
 			part.EdgeBanding = model.EdgeBanding{
 				Top:    bandTop.Checked,
 				Bottom: bandBottom.Checked,
@@ -475,6 +486,10 @@ func (a *App) showEditPartDialog(idx int) {
 	grainSelect := widget.NewSelect([]string{"None", "Horizontal", "Vertical"}, nil)
 	grainSelect.SetSelected(p.Grain.String())
 
+	editMaterialEntry := widget.NewEntry()
+	editMaterialEntry.SetPlaceHolder("e.g., Plywood, MDF (optional)")
+	editMaterialEntry.SetText(p.Material)
+
 	bandTop := widget.NewCheck("Top", nil)
 	bandTop.Checked = p.EdgeBanding.Top
 	bandBottom := widget.NewCheck("Bottom", nil)
@@ -492,6 +507,7 @@ func (a *App) showEditPartDialog(idx int) {
 			widget.NewFormItem("Height (mm)", heightEntry),
 			widget.NewFormItem("Quantity", qtyEntry),
 			widget.NewFormItem("Grain", grainSelect),
+			widget.NewFormItem("Material", editMaterialEntry),
 			widget.NewFormItem("Edge Banding", bandingRow),
 		},
 		func(ok bool) {
@@ -520,6 +536,7 @@ func (a *App) showEditPartDialog(idx int) {
 			default:
 				a.project.Parts[idx].Grain = model.GrainNone
 			}
+			a.project.Parts[idx].Material = strings.TrimSpace(editMaterialEntry.Text)
 			a.project.Parts[idx].EdgeBanding = model.EdgeBanding{
 				Top:    bandTop.Checked,
 				Bottom: bandBottom.Checked,
@@ -568,12 +585,13 @@ func (a *App) refreshStockList() {
 		return
 	}
 
-	header := container.NewGridWithColumns(8,
+	header := container.NewGridWithColumns(9,
 		widget.NewLabelWithStyle("Label", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Width (mm)", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Height (mm)", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Qty", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Grain", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Material", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Price/Sheet", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{}),
 		widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{}),
@@ -588,12 +606,17 @@ func (a *App) refreshStockList() {
 		if s.PricePerSheet > 0 {
 			priceLabel = fmt.Sprintf("%.2f", s.PricePerSheet)
 		}
-		row := container.NewGridWithColumns(8,
+		stockMatLabel := "-"
+		if s.Material != "" {
+			stockMatLabel = s.Material
+		}
+		row := container.NewGridWithColumns(9,
 			widget.NewLabel(s.Label),
 			widget.NewLabel(fmt.Sprintf("%.1f", s.Width)),
 			widget.NewLabel(fmt.Sprintf("%.1f", s.Height)),
 			widget.NewLabel(fmt.Sprintf("%d", s.Quantity)),
 			widget.NewLabel(s.Grain.String()),
+			widget.NewLabel(stockMatLabel),
 			widget.NewLabel(priceLabel),
 			widget.NewButtonWithIcon("", theme.DocumentCreateIcon(), func() {
 				a.showEditStockDialog(idx)
@@ -661,6 +684,9 @@ func (a *App) showAddStockDialog() {
 	grainSelect := widget.NewSelect([]string{"None", "Horizontal", "Vertical"}, nil)
 	grainSelect.SetSelected("None")
 
+	stockMaterialEntry := widget.NewEntry()
+	stockMaterialEntry.SetPlaceHolder("e.g., Plywood, MDF (optional)")
+
 	priceEntry := widget.NewEntry()
 	priceEntry.SetPlaceHolder("0.00 (optional)")
 	priceEntry.SetText("0")
@@ -673,6 +699,7 @@ func (a *App) showAddStockDialog() {
 			widget.NewFormItem("Height (mm)", heightEntry),
 			widget.NewFormItem("Quantity", qtyEntry),
 			widget.NewFormItem("Grain Direction", grainSelect),
+			widget.NewFormItem("Material", stockMaterialEntry),
 			widget.NewFormItem("Price per Sheet", priceEntry),
 		},
 		func(ok bool) {
@@ -694,6 +721,7 @@ func (a *App) showAddStockDialog() {
 			case "Vertical":
 				sheet.Grain = model.GrainVertical
 			}
+			sheet.Material = strings.TrimSpace(stockMaterialEntry.Text)
 			sheet.PricePerSheet, _ = strconv.ParseFloat(priceEntry.Text, 64)
 			a.project.Stocks = append(a.project.Stocks, sheet)
 			a.refreshStockList()
@@ -722,6 +750,10 @@ func (a *App) showEditStockDialog(idx int) {
 	grainSelect := widget.NewSelect([]string{"None", "Horizontal", "Vertical"}, nil)
 	grainSelect.SetSelected(s.Grain.String())
 
+	editStockMaterialEntry := widget.NewEntry()
+	editStockMaterialEntry.SetPlaceHolder("e.g., Plywood, MDF (optional)")
+	editStockMaterialEntry.SetText(s.Material)
+
 	priceEntry := widget.NewEntry()
 	priceEntry.SetText(fmt.Sprintf("%.2f", s.PricePerSheet))
 
@@ -732,6 +764,7 @@ func (a *App) showEditStockDialog(idx int) {
 			widget.NewFormItem("Height (mm)", heightEntry),
 			widget.NewFormItem("Quantity", qtyEntry),
 			widget.NewFormItem("Grain Direction", grainSelect),
+			widget.NewFormItem("Material", editStockMaterialEntry),
 			widget.NewFormItem("Price per Sheet", priceEntry),
 		},
 		func(ok bool) {
@@ -758,6 +791,7 @@ func (a *App) showEditStockDialog(idx int) {
 			default:
 				a.project.Stocks[idx].Grain = model.GrainNone
 			}
+			a.project.Stocks[idx].Material = strings.TrimSpace(editStockMaterialEntry.Text)
 			a.project.Stocks[idx].PricePerSheet, _ = strconv.ParseFloat(priceEntry.Text, 64)
 			a.refreshStockList()
 		},


### PR DESCRIPTION
## Summary

- Adds a `Material` field to both `Part` and `StockSheet` structs (optional, backward-compatible)
- Optimizer groups parts and stocks by material type before running the packing algorithm
- Parts with a specific material are only placed on stocks of the same material
- Parts or stocks with empty material act as universal (compatible with anything)
- UI updated: Material column and entry fields in both parts and stock sheet lists/dialogs
- 9 new tests covering multi-material grouping, separation, universal parts/stocks, and backward compatibility

## Test Plan

- [x] All existing tests pass (no regressions)
- [x] New tests verify material grouping logic
- [x] Build succeeds on macOS
- [x] Backward compatible: no material set = same behavior as before

Resolves #36