### PR TITLE
[Feature] Add project templates for saving and loading configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Purchasing Calculator** — Calculate sheets needed, board feet, and estimated cost with configurable waste factor (Tools menu)
 - **Edge Banding Calculator** — Mark which edges need banding per part (T/B/L/R); view per-part and total banding length with waste factor in results
 - **What-If Comparison** — Compare multiple optimization scenarios side by side (algorithm, kerf, edge trim) and apply the best result
+- **Project Templates** — Save and load reusable project templates (parts, stocks, settings) from the Admin menu
 - **Admin Menu** — Application settings, inventory management, data backup/restore
 - **Stock Size Presets** — Quick-select dropdown with common panel sizes (Full, Half, Quarter sheet, Euro sizes)
 
@@ -108,6 +109,7 @@ SlabCut/
 │   │   ├── model.go            # Core types (Part, StockSheet, Placement, etc.)
 │   │   ├── inventory.go        # Tool/stock inventory types
 │   │   ├── library.go          # Parts library types
+│   │   ├── template.go         # Project template types
 │   │   └── appconfig.go        # Application configuration
 │   ├── engine/
 │   │   ├── optimizer.go        # Guillotine bin-packing algorithm
@@ -126,6 +128,7 @@ SlabCut/
 │   │   ├── profiles.go         # Custom GCode profile persistence
 │   │   ├── inventory.go        # Tool/stock inventory persistence
 │   │   ├── library.go          # Parts library persistence
+│   │   ├── templates.go        # Project template persistence
 │   │   └── appconfig.go        # App config persistence
 │   └── ui/
 │       ├── app.go              # Main UI (tabs, menus, dialogs)

--- a/internal/model/template.go
+++ b/internal/model/template.go
@@ -1,0 +1,137 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ProjectTemplate represents a reusable project configuration that captures
+// parts, stock sheets, and settings but not optimization results.
+type ProjectTemplate struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	CreatedAt   string       `json:"created_at"`
+	UpdatedAt   string       `json:"updated_at"`
+	Parts       []Part       `json:"parts"`
+	Stocks      []StockSheet `json:"stocks"`
+	Settings    CutSettings  `json:"settings"`
+}
+
+// NewProjectTemplate creates a new template from the given project data.
+// It copies parts, stocks, and settings but intentionally excludes results.
+func NewProjectTemplate(name, description string, parts []Part, stocks []StockSheet, settings CutSettings) ProjectTemplate {
+	now := time.Now().UTC().Format(time.RFC3339)
+	return ProjectTemplate{
+		ID:          uuid.New().String()[:8],
+		Name:        name,
+		Description: description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Parts:       copyParts(parts),
+		Stocks:      copyStocks(stocks),
+		Settings:    settings,
+	}
+}
+
+// ToProject creates a new Project from this template.
+// Parts and stocks get fresh IDs so they are independent of the template.
+func (t ProjectTemplate) ToProject(projectName string) Project {
+	parts := make([]Part, len(t.Parts))
+	for i, p := range t.Parts {
+		parts[i] = NewPart(p.Label, p.Width, p.Height, p.Quantity)
+		parts[i].Grain = p.Grain
+		parts[i].Outline = p.Outline
+	}
+
+	stocks := make([]StockSheet, len(t.Stocks))
+	for i, s := range t.Stocks {
+		stocks[i] = NewStockSheet(s.Label, s.Width, s.Height, s.Quantity)
+		stocks[i].Tabs = s.Tabs
+	}
+
+	return Project{
+		Name:     projectName,
+		Parts:    parts,
+		Stocks:   stocks,
+		Settings: t.Settings,
+	}
+}
+
+// TemplateStore holds a collection of project templates.
+type TemplateStore struct {
+	Templates []ProjectTemplate `json:"templates"`
+}
+
+// NewTemplateStore creates an empty template store.
+func NewTemplateStore() TemplateStore {
+	return TemplateStore{
+		Templates: []ProjectTemplate{},
+	}
+}
+
+// Add adds a template to the store.
+func (ts *TemplateStore) Add(t ProjectTemplate) {
+	ts.Templates = append(ts.Templates, t)
+}
+
+// Remove removes a template by ID. Returns true if found and removed.
+func (ts *TemplateStore) Remove(id string) bool {
+	for i, t := range ts.Templates {
+		if t.ID == id {
+			ts.Templates = append(ts.Templates[:i], ts.Templates[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// FindByID returns a pointer to the template with the given ID, or nil.
+func (ts *TemplateStore) FindByID(id string) *ProjectTemplate {
+	for i := range ts.Templates {
+		if ts.Templates[i].ID == id {
+			return &ts.Templates[i]
+		}
+	}
+	return nil
+}
+
+// Names returns a list of template names for UI dropdowns.
+func (ts *TemplateStore) Names() []string {
+	names := make([]string, len(ts.Templates))
+	for i, t := range ts.Templates {
+		names[i] = t.Name
+	}
+	return names
+}
+
+// FindByName returns a pointer to the first template with the given name, or nil.
+func (ts *TemplateStore) FindByName(name string) *ProjectTemplate {
+	for i := range ts.Templates {
+		if ts.Templates[i].Name == name {
+			return &ts.Templates[i]
+		}
+	}
+	return nil
+}
+
+// copyParts creates a deep copy of a parts slice.
+func copyParts(parts []Part) []Part {
+	if parts == nil {
+		return []Part{}
+	}
+	cp := make([]Part, len(parts))
+	copy(cp, parts)
+	return cp
+}
+
+// copyStocks creates a deep copy of a stocks slice.
+func copyStocks(stocks []StockSheet) []StockSheet {
+	if stocks == nil {
+		return []StockSheet{}
+	}
+	cp := make([]StockSheet, len(stocks))
+	copy(cp, stocks)
+	return cp
+}

--- a/internal/model/template_test.go
+++ b/internal/model/template_test.go
@@ -1,0 +1,149 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestNewProjectTemplate(t *testing.T) {
+	parts := []Part{
+		NewPart("Side", 600, 400, 2),
+		NewPart("Top", 500, 300, 1),
+	}
+	stocks := []StockSheet{
+		NewStockSheet("Plywood", 2440, 1220, 1),
+	}
+	settings := DefaultSettings()
+
+	tmpl := NewProjectTemplate("Cabinet", "Standard cabinet template", parts, stocks, settings)
+
+	if tmpl.Name != "Cabinet" {
+		t.Errorf("expected name 'Cabinet', got %q", tmpl.Name)
+	}
+	if tmpl.Description != "Standard cabinet template" {
+		t.Errorf("expected description 'Standard cabinet template', got %q", tmpl.Description)
+	}
+	if tmpl.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if tmpl.CreatedAt == "" {
+		t.Error("expected non-empty CreatedAt")
+	}
+	if len(tmpl.Parts) != 2 {
+		t.Errorf("expected 2 parts, got %d", len(tmpl.Parts))
+	}
+	if len(tmpl.Stocks) != 1 {
+		t.Errorf("expected 1 stock, got %d", len(tmpl.Stocks))
+	}
+}
+
+func TestProjectTemplate_ToProject(t *testing.T) {
+	parts := []Part{
+		NewPart("Side", 600, 400, 2),
+	}
+	stocks := []StockSheet{
+		NewStockSheet("Plywood", 2440, 1220, 1),
+	}
+	settings := DefaultSettings()
+	settings.KerfWidth = 5.0
+
+	tmpl := NewProjectTemplate("Test", "desc", parts, stocks, settings)
+	proj := tmpl.ToProject("My Project")
+
+	if proj.Name != "My Project" {
+		t.Errorf("expected project name 'My Project', got %q", proj.Name)
+	}
+	if len(proj.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(proj.Parts))
+	}
+	if proj.Parts[0].Label != "Side" {
+		t.Errorf("expected part label 'Side', got %q", proj.Parts[0].Label)
+	}
+	// Parts should have fresh IDs
+	if proj.Parts[0].ID == tmpl.Parts[0].ID {
+		t.Error("project parts should have fresh IDs, not template IDs")
+	}
+	if proj.Settings.KerfWidth != 5.0 {
+		t.Errorf("expected kerf width 5.0, got %.1f", proj.Settings.KerfWidth)
+	}
+	if proj.Result != nil {
+		t.Error("project from template should have no result")
+	}
+}
+
+func TestTemplateStore_AddRemoveFind(t *testing.T) {
+	store := NewTemplateStore()
+
+	tmpl1 := NewProjectTemplate("T1", "", nil, nil, DefaultSettings())
+	tmpl2 := NewProjectTemplate("T2", "", nil, nil, DefaultSettings())
+
+	store.Add(tmpl1)
+	store.Add(tmpl2)
+
+	if len(store.Templates) != 2 {
+		t.Fatalf("expected 2 templates, got %d", len(store.Templates))
+	}
+
+	// FindByID
+	found := store.FindByID(tmpl1.ID)
+	if found == nil {
+		t.Fatal("FindByID returned nil for existing template")
+	}
+	if found.Name != "T1" {
+		t.Errorf("expected 'T1', got %q", found.Name)
+	}
+
+	// FindByName
+	found = store.FindByName("T2")
+	if found == nil {
+		t.Fatal("FindByName returned nil for existing template")
+	}
+
+	// Names
+	names := store.Names()
+	if len(names) != 2 {
+		t.Errorf("expected 2 names, got %d", len(names))
+	}
+
+	// Remove
+	ok := store.Remove(tmpl1.ID)
+	if !ok {
+		t.Error("Remove should return true for existing template")
+	}
+	if len(store.Templates) != 1 {
+		t.Errorf("expected 1 template after remove, got %d", len(store.Templates))
+	}
+
+	// Remove non-existent
+	ok = store.Remove("nonexistent")
+	if ok {
+		t.Error("Remove should return false for non-existent ID")
+	}
+}
+
+func TestTemplateStore_Empty(t *testing.T) {
+	store := NewTemplateStore()
+
+	if len(store.Templates) != 0 {
+		t.Errorf("new store should be empty, got %d templates", len(store.Templates))
+	}
+	if store.FindByID("x") != nil {
+		t.Error("FindByID should return nil in empty store")
+	}
+	if store.FindByName("x") != nil {
+		t.Error("FindByName should return nil in empty store")
+	}
+	if len(store.Names()) != 0 {
+		t.Error("Names should return empty slice for empty store")
+	}
+}
+
+func TestNewProjectTemplate_NilSlices(t *testing.T) {
+	tmpl := NewProjectTemplate("Empty", "", nil, nil, DefaultSettings())
+
+	if tmpl.Parts == nil {
+		t.Error("Parts should not be nil (should be empty slice)")
+	}
+	if tmpl.Stocks == nil {
+		t.Error("Stocks should not be nil (should be empty slice)")
+	}
+}

--- a/internal/project/templates.go
+++ b/internal/project/templates.go
@@ -1,0 +1,74 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// DefaultTemplatePath returns the default file path for the templates store.
+// This is located at ~/.slabcut/templates.json.
+func DefaultTemplatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".slabcut")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "templates.json"), nil
+}
+
+// SaveTemplates writes the template store to a JSON file.
+func SaveTemplates(path string, store model.TemplateStore) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadTemplates reads a template store from a JSON file.
+// If the file does not exist, returns an empty store.
+func LoadTemplates(path string) (model.TemplateStore, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return model.NewTemplateStore(), nil
+		}
+		return model.TemplateStore{}, err
+	}
+	var store model.TemplateStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return model.TemplateStore{}, err
+	}
+	if store.Templates == nil {
+		store.Templates = []model.ProjectTemplate{}
+	}
+	return store, nil
+}
+
+// LoadDefaultTemplates loads templates from the default path.
+func LoadDefaultTemplates() (model.TemplateStore, error) {
+	path, err := DefaultTemplatePath()
+	if err != nil {
+		return model.NewTemplateStore(), err
+	}
+	return LoadTemplates(path)
+}
+
+// SaveDefaultTemplates saves templates to the default path.
+func SaveDefaultTemplates(store model.TemplateStore) error {
+	path, err := DefaultTemplatePath()
+	if err != nil {
+		return err
+	}
+	return SaveTemplates(path, store)
+}

--- a/internal/project/templates_test.go
+++ b/internal/project/templates_test.go
@@ -1,0 +1,75 @@
+package project
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+func TestSaveAndLoadTemplates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "templates.json")
+
+	store := model.NewTemplateStore()
+	parts := []model.Part{model.NewPart("Shelf", 500, 300, 2)}
+	stocks := []model.StockSheet{model.NewStockSheet("Board", 2440, 1220, 1)}
+	settings := model.DefaultSettings()
+
+	tmpl := model.NewProjectTemplate("Cabinet", "Standard cabinet", parts, stocks, settings)
+	store.Add(tmpl)
+
+	if err := SaveTemplates(path, store); err != nil {
+		t.Fatalf("SaveTemplates error: %v", err)
+	}
+
+	loaded, err := LoadTemplates(path)
+	if err != nil {
+		t.Fatalf("LoadTemplates error: %v", err)
+	}
+
+	if len(loaded.Templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(loaded.Templates))
+	}
+	if loaded.Templates[0].Name != "Cabinet" {
+		t.Errorf("expected 'Cabinet', got %q", loaded.Templates[0].Name)
+	}
+	if len(loaded.Templates[0].Parts) != 1 {
+		t.Errorf("expected 1 part, got %d", len(loaded.Templates[0].Parts))
+	}
+}
+
+func TestLoadTemplates_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	store, err := LoadTemplates(path)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if len(store.Templates) != 0 {
+		t.Errorf("expected empty store, got %d templates", len(store.Templates))
+	}
+}
+
+func TestSaveAndLoadTemplates_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "templates.json")
+
+	store := model.NewTemplateStore()
+	store.Add(model.NewProjectTemplate("T1", "First", nil, nil, model.DefaultSettings()))
+	store.Add(model.NewProjectTemplate("T2", "Second", nil, nil, model.DefaultSettings()))
+	store.Add(model.NewProjectTemplate("T3", "Third", nil, nil, model.DefaultSettings()))
+
+	if err := SaveTemplates(path, store); err != nil {
+		t.Fatalf("SaveTemplates error: %v", err)
+	}
+
+	loaded, err := LoadTemplates(path)
+	if err != nil {
+		t.Fatalf("LoadTemplates error: %v", err)
+	}
+	if len(loaded.Templates) != 3 {
+		t.Fatalf("expected 3 templates, got %d", len(loaded.Templates))
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -36,6 +36,9 @@ type App struct {
 	inventory     model.Inventory
 	inventoryPath string
 
+	// Template management
+	templates model.TemplateStore
+
 	// UI references for dynamic updates
 	partsContainer  *fyne.Container
 	stockContainer  *fyne.Container
@@ -68,6 +71,7 @@ func NewApp(application fyne.App, window fyne.Window) *App {
 	}
 	app.loadCustomProfiles()
 	app.loadInventory()
+	app.loadTemplates()
 	app.applyTheme()
 	return app
 }
@@ -94,6 +98,17 @@ func (a *App) loadInventory() {
 	}
 	a.inventory = inv
 	a.inventoryPath = path
+}
+
+// loadTemplates loads project templates from disk on startup.
+func (a *App) loadTemplates() {
+	store, err := project.LoadDefaultTemplates()
+	if err != nil {
+		fmt.Printf("Warning: could not load templates: %v\n", err)
+		a.templates = model.NewTemplateStore()
+		return
+	}
+	a.templates = store
 }
 
 // loadCustomProfiles loads user-defined GCode profiles from disk on startup.
@@ -208,6 +223,9 @@ func (a *App) SetupMenus() {
 		}),
 		fyne.NewMenuItem("Stock Inventory...", func() {
 			a.showStockInventoryDialog()
+		}),
+		fyne.NewMenuItem("Project Templates...", func() {
+			a.showTemplateManager()
 		}),
 		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Import/Export Data...", func() {


### PR DESCRIPTION
## Summary
- Add ProjectTemplate and TemplateStore types in internal/model/template.go
- Add template persistence (save/load to ~/.slabcut/templates.json) in internal/project/templates.go
- Add template management UI dialog to Admin menu with save-as-template, load, and delete operations
- Templates capture parts, stock sheets, and settings (excluding optimization results)
- Loading a template creates a fresh project with new IDs for all parts/stocks

## Test plan
- [x] Unit tests for template creation, ToProject conversion, TemplateStore CRUD
- [x] Persistence tests for save/load/not-found
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/slabcut`)

Resolves #77