### PR TITLE
[Feature] Add automatic nesting of interior cutouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Part Rotation** — Automatically rotates parts for better fit (respects grain)
 - **Multiple Stock Sizes** — Use different stock sheet sizes in one run with smart selection (trial-packing heuristic)
 - **Multi-Material Optimization** — Assign material types (e.g., Plywood, MDF) to parts and stock sheets; optimizer groups by material so parts are only placed on matching stocks
+- **Interior Cutout Nesting** — Automatically nests smaller parts inside the waste holes of larger parts with cutouts, maximizing material utilization
 - **Fixture / Clamp Zones** — Define rectangular exclusion zones for clamps and fixtures; optimizer avoids placing parts in these areas
 
 ### CNC & GCode

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -351,13 +351,14 @@ func (a *App) refreshPartsList() {
 	}
 
 	// Header
-	header := container.NewGridWithColumns(10,
+	header := container.NewGridWithColumns(11,
 		widget.NewLabelWithStyle("Label", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Width (mm)", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Height (mm)", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Qty", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Grain", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Material", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Cutouts", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("Banding", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{}),
 		widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{}),
@@ -373,13 +374,18 @@ func (a *App) refreshPartsList() {
 		if p.Material != "" {
 			matLabel = p.Material
 		}
-		row := container.NewGridWithColumns(10,
+		cutoutLabel := "-"
+		if len(p.Cutouts) > 0 {
+			cutoutLabel = fmt.Sprintf("%d", len(p.Cutouts))
+		}
+		row := container.NewGridWithColumns(11,
 			widget.NewLabel(p.Label),
 			widget.NewLabel(fmt.Sprintf("%.1f", p.Width)),
 			widget.NewLabel(fmt.Sprintf("%.1f", p.Height)),
 			widget.NewLabel(fmt.Sprintf("%d", p.Quantity)),
 			widget.NewLabel(p.Grain.String()),
 			widget.NewLabel(matLabel),
+			widget.NewLabel(cutoutLabel),
 			widget.NewLabel(p.EdgeBanding.String()),
 			widget.NewButtonWithIcon("", theme.DocumentCreateIcon(), func() {
 				a.showEditPartDialog(idx)


### PR DESCRIPTION
## Summary

- Adds `Cutouts []Outline` field to the Part struct for defining interior holes/cutouts
- Adds `CutoutBounds()` method to extract bounding rectangles from cutout polygons
- Optimizer injects cutout bounding rects as free space after placing a part, allowing smaller parts to be nested inside waste holes
- Works with both guillotine and genetic algorithm optimizers
- UI shows cutout count in the parts list
- 5 new tests for cutout bounds calculation and nesting behavior

## Test Plan

- [x] All existing tests pass (no regressions)
- [x] New tests verify cutout nesting logic
- [x] Build succeeds on macOS
- [x] Backward compatible: parts without cutouts work identically

Resolves #27