### PR TITLE
[Feature] Add collaborative mode with project sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **PDF Export** — Multi-page cut diagrams with dimensions, labels, efficiency stats, and summary
 - **QR Label Export** — Generate printable QR-coded labels for cut parts with part name, dimensions, and sheet position (Avery 5160 layout)
 - **GCode Export** — Per-sheet GCode files with configurable profiles
+- **Project Sharing** — Export projects as `.slabshare` files with author, notes, and metadata for team collaboration; import shared projects with preview
 - **Project Save/Load** — JSON-based project files (`.cnccalc`)
 
 ### User Interface
@@ -130,6 +131,7 @@ SlabCut/
 │   │   ├── inventory.go        # Tool/stock inventory persistence
 │   │   ├── library.go          # Parts library persistence
 │   │   ├── templates.go        # Project template persistence
+│   │   ├── sharing.go          # Project sharing/collaboration
 │   │   └── appconfig.go        # App config persistence
 │   └── ui/
 │       ├── app.go              # Main UI (tabs, menus, dialogs)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -760,8 +760,22 @@ func (or OptimizeResult) HasPricing() bool {
 }
 
 // Project ties everything together for save/load.
+// ProjectMetadata holds sharing and collaboration metadata for a project.
+type ProjectMetadata struct {
+	Author      string `json:"author,omitempty"`
+	Email       string `json:"email,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+	Notes       string `json:"notes,omitempty"`
+	Version     string `json:"version,omitempty"`
+	SharedFrom  string `json:"shared_from,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Project ties everything together for save/load.
 type Project struct {
 	Name     string          `json:"name"`
+	Metadata ProjectMetadata `json:"metadata,omitempty"`
 	Parts    []Part          `json:"parts"`
 	Stocks   []StockSheet    `json:"stocks"`
 	Settings CutSettings     `json:"settings"`

--- a/internal/project/sharing.go
+++ b/internal/project/sharing.go
@@ -1,0 +1,86 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// SharedProject is the file format for shared projects.
+// It wraps a Project with additional sharing metadata to distinguish
+// shared files from regular project saves.
+type SharedProject struct {
+	FormatVersion string        `json:"format_version"`
+	SharedAt      string        `json:"shared_at"`
+	SharedBy      string        `json:"shared_by"`
+	Project       model.Project `json:"project"`
+}
+
+// ExportShared exports a project as a shareable file. The shared format
+// includes the full project data plus sharing metadata. The author name
+// and notes are embedded in the project metadata.
+func ExportShared(path string, proj model.Project, author, notes string) error {
+	// Update project metadata for sharing
+	now := time.Now().UTC().Format(time.RFC3339)
+	proj.Metadata.UpdatedAt = now
+	if proj.Metadata.CreatedAt == "" {
+		proj.Metadata.CreatedAt = now
+	}
+	proj.Metadata.Author = author
+	proj.Metadata.Notes = notes
+	proj.Metadata.Version = "1.0"
+
+	shared := SharedProject{
+		FormatVersion: "1.0",
+		SharedAt:      now,
+		SharedBy:      author,
+		Project:       proj,
+	}
+
+	data, err := json.MarshalIndent(shared, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal shared project: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write shared project: %w", err)
+	}
+	return nil
+}
+
+// ImportShared imports a shared project file. It handles both the shared
+// format (SharedProject wrapper) and plain project files for backward
+// compatibility. Returns the imported project with metadata populated.
+func ImportShared(path string) (model.Project, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return model.Project{}, fmt.Errorf("failed to read shared file: %w", err)
+	}
+
+	// Try parsing as SharedProject first
+	var shared SharedProject
+	if err := json.Unmarshal(data, &shared); err == nil && shared.FormatVersion != "" {
+		proj := shared.Project
+		if proj.Metadata.SharedFrom == "" {
+			proj.Metadata.SharedFrom = shared.SharedBy
+		}
+		return proj, nil
+	}
+
+	// Fall back to plain project format
+	var proj model.Project
+	if err := json.Unmarshal(data, &proj); err != nil {
+		return model.Project{}, fmt.Errorf("failed to parse project file: %w", err)
+	}
+
+	return proj, nil
+}

--- a/internal/project/sharing_test.go
+++ b/internal/project/sharing_test.go
@@ -1,0 +1,163 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+func TestExportShared_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.slabshare")
+
+	proj := model.NewProject()
+	proj.Name = "Test Project"
+	proj.Parts = append(proj.Parts, model.NewPart("Shelf", 500, 300, 2))
+	proj.Stocks = append(proj.Stocks, model.NewStockSheet("Board", 2440, 1220, 1))
+
+	err := ExportShared(path, proj, "Test User", "Shared for review")
+	if err != nil {
+		t.Fatalf("ExportShared error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("shared file was not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("shared file is empty")
+	}
+}
+
+func TestExportAndImportShared_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.slabshare")
+
+	proj := model.NewProject()
+	proj.Name = "My Cabinet"
+	proj.Parts = append(proj.Parts, model.NewPart("Side", 600, 400, 2))
+	proj.Parts = append(proj.Parts, model.NewPart("Top", 500, 300, 1))
+	proj.Stocks = append(proj.Stocks, model.NewStockSheet("Plywood", 2440, 1220, 1))
+
+	err := ExportShared(path, proj, "Pascal", "For team review")
+	if err != nil {
+		t.Fatalf("ExportShared error: %v", err)
+	}
+
+	imported, err := ImportShared(path)
+	if err != nil {
+		t.Fatalf("ImportShared error: %v", err)
+	}
+
+	if imported.Name != "My Cabinet" {
+		t.Errorf("expected name 'My Cabinet', got %q", imported.Name)
+	}
+	if len(imported.Parts) != 2 {
+		t.Errorf("expected 2 parts, got %d", len(imported.Parts))
+	}
+	if len(imported.Stocks) != 1 {
+		t.Errorf("expected 1 stock, got %d", len(imported.Stocks))
+	}
+	if imported.Metadata.Author != "Pascal" {
+		t.Errorf("expected author 'Pascal', got %q", imported.Metadata.Author)
+	}
+	if imported.Metadata.Notes != "For team review" {
+		t.Errorf("expected notes 'For team review', got %q", imported.Metadata.Notes)
+	}
+	if imported.Metadata.CreatedAt == "" {
+		t.Error("expected non-empty CreatedAt")
+	}
+	if imported.Metadata.SharedFrom != "Pascal" {
+		t.Errorf("expected SharedFrom 'Pascal', got %q", imported.Metadata.SharedFrom)
+	}
+}
+
+func TestImportShared_PlainProject(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plain.cnccalc")
+
+	// Create a plain project file (backward compatibility)
+	proj := model.NewProject()
+	proj.Name = "Plain Project"
+	proj.Parts = append(proj.Parts, model.NewPart("Part A", 200, 100, 1))
+
+	data, err := json.MarshalIndent(proj, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	imported, err := ImportShared(path)
+	if err != nil {
+		t.Fatalf("ImportShared error: %v", err)
+	}
+
+	if imported.Name != "Plain Project" {
+		t.Errorf("expected 'Plain Project', got %q", imported.Name)
+	}
+	if len(imported.Parts) != 1 {
+		t.Errorf("expected 1 part, got %d", len(imported.Parts))
+	}
+}
+
+func TestImportShared_InvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.json")
+	if err := os.WriteFile(path, []byte("not json"), 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	_, err := ImportShared(path)
+	if err == nil {
+		t.Fatal("expected error for invalid file, got nil")
+	}
+}
+
+func TestImportShared_FileNotFound(t *testing.T) {
+	_, err := ImportShared("/nonexistent/path/file.json")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestExportShared_MetadataPopulated(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.slabshare")
+
+	proj := model.NewProject()
+	proj.Name = "Meta Test"
+
+	err := ExportShared(path, proj, "Team Lead", "Review needed")
+	if err != nil {
+		t.Fatalf("ExportShared error: %v", err)
+	}
+
+	// Read and verify the file structure
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+
+	var shared SharedProject
+	if err := json.Unmarshal(data, &shared); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if shared.FormatVersion != "1.0" {
+		t.Errorf("expected format version '1.0', got %q", shared.FormatVersion)
+	}
+	if shared.SharedBy != "Team Lead" {
+		t.Errorf("expected shared by 'Team Lead', got %q", shared.SharedBy)
+	}
+	if shared.SharedAt == "" {
+		t.Error("expected non-empty SharedAt")
+	}
+	if shared.Project.Metadata.Version != "1.0" {
+		t.Errorf("expected version '1.0', got %q", shared.Project.Metadata.Version)
+	}
+}


### PR DESCRIPTION
## Summary
- Add ProjectMetadata struct with author, email, timestamps, notes, version, and shared-from fields
- Add .slabshare file format for project sharing with versioned wrapper and backward compatibility
- Add Share Project and Import Shared Project menu items in File menu
- Share dialog captures author name and notes; import dialog shows project preview before applying
- Shared format falls back gracefully to plain .cnccalc project files

## Test plan
- [x] Round-trip test for export/import shared projects
- [x] Plain project backward compatibility test
- [x] Invalid file and missing file error handling tests
- [x] Metadata population and SharedFrom tracking test
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/slabcut`)

Resolves #78