### PR TITLE
[Feature] Add multi-objective optimization with weighted priorities (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Interior Cutout Nesting** — Automatically nests smaller parts inside the waste holes of larger parts with cutouts, maximizing material utilization
 - **Fixture / Clamp Zones** — Define rectangular exclusion zones for clamps and fixtures; optimizer avoids placing parts in these areas
 - **Dust Shoe Collision Detection** — Automatically checks for collisions between the dust shoe and clamp/fixture zones after optimization; warns before generating GCode
+- **Multi-Objective Optimization** — Weight priorities for minimize waste, minimize sheets, minimize cut length, and minimize job time; genetic algorithm uses weighted multi-objective fitness scoring
 
 ### CNC & GCode
 - **GCode Export** — Full CNC toolpath generation with:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -978,8 +978,16 @@ func (a *App) buildSettingsPanel() fyne.CanvasObject {
 		),
 	)
 
+	weightsSection := widget.NewCard("Optimization Objectives", "Weight priorities for multi-objective optimization (0 = disabled, higher = more important)", container.NewGridWithColumns(2,
+		widget.NewLabel("Minimize Waste"), floatEntry(&s.OptimizeWeights.MinimizeWaste),
+		widget.NewLabel("Minimize Sheets"), floatEntry(&s.OptimizeWeights.MinimizeSheets),
+		widget.NewLabel("Minimize Cut Length"), floatEntry(&s.OptimizeWeights.MinimizeCutLen),
+		widget.NewLabel("Minimize Job Time"), floatEntry(&s.OptimizeWeights.MinimizeJobTime),
+	))
+
 	return container.NewVScroll(container.NewVBox(
 		optimizerSection,
+		weightsSection,
 		cncSection,
 		plungeSection,
 		leadInOutSection,


### PR DESCRIPTION
## Summary

- Adds weighted multi-objective fitness scoring to the genetic algorithm optimizer
- Four optimization objectives: minimize waste, minimize sheets, minimize cut length, minimize job time
- Weights are normalized internally; relative proportions determine priority
- New UI section with float entry fields for each objective weight
- Added Outline.Perimeter(), OptimizeResult.TotalCutLength(), EstimatedJobTime() helper methods
- 12 tests covering weights, normalization, cut length, job time, and GA integration

## Test Plan

- [x] All 12 new multi-objective tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/slabcut`)
- [x] README updated

Resolves #46