### PR TITLE
[Feature] Add non-rectangular part nesting with multi-angle rotation (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Fixture / Clamp Zones** — Define rectangular exclusion zones for clamps and fixtures; optimizer avoids placing parts in these areas
 - **Dust Shoe Collision Detection** — Automatically checks for collisions between the dust shoe and clamp/fixture zones after optimization; warns before generating GCode
 - **Multi-Objective Optimization** — Weight priorities for minimize waste, minimize sheets, minimize cut length, and minimize job time; genetic algorithm uses weighted multi-objective fitness scoring
+- **Non-Rectangular Nesting** — Outline parts can be rotated at multiple angles (configurable: 2/4/8+ rotations) to find tighter bounding-box fits; includes polygon overlap detection, area calculation, and point-in-polygon testing
 
 ### CNC & GCode
 - **GCode Export** — Full CNC toolpath generation with:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -886,6 +886,7 @@ func (a *App) buildSettingsPanel() fyne.CanvasObject {
 		widget.NewLabel("Kerf / Blade Width (mm)"), floatEntry(&s.KerfWidth),
 		widget.NewLabel("Edge Trim (mm)"), floatEntry(&s.EdgeTrim),
 		widget.NewLabel("Guillotine Cuts Only"), widget.NewCheck("", func(b bool) { s.GuillotineOnly = b }),
+		widget.NewLabel("Nesting Rotations (outline parts)"), intEntry(&s.NestingRotations),
 	))
 
 	optimizeToolpathCheck := widget.NewCheck("", func(b bool) { s.OptimizeToolpath = b })


### PR DESCRIPTION
## Summary

- Adds multi-angle rotation nesting for outline (non-rectangular) parts
- Tries configurable number of rotation angles (default 2, can be 4/8+) to find tightest bounding-box fit
- Includes polygon geometry utilities: Outline.Rotate(), Area(), ContainsPoint(), and OutlinesOverlap()
- Parts with grain constraints bypass multi-rotation (grain takes priority)
- New UI field for configuring nesting rotations in optimizer settings
- 14 tests covering rotation, area, containment, polygon overlap, and optimizer integration

## Test Plan

- [x] All 14 new non-rectangular nesting tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/slabcut`)
- [x] README updated

Resolves #43