### PR TITLE
[Feature] OrcaSlicer-inspired 2-tab UI with live optimization (#103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ github.com/piwi3910/SlabCut/
 │   ├── importer/           # CSV/Excel/DXF import
 │   ├── export/             # PDF export
 │   ├── ui/                 # Main Fyne UI, dialogs, admin, profile editor
+│   │   │                   #   app.go — 2-tab layout (Layout Editor + GCode Preview)
+│   │   │                   #   advanced_settings.go — Advanced CNC settings dialog
 │   │   └── widgets/        # Custom Fyne widgets (SheetCanvas, GCodePreview)
 │   ├── project/            # Project/profile/inventory/library/config persistence
 │   ├── version/            # Build-time version/commit info (ldflags)
@@ -116,18 +118,21 @@ Examples: `issue-42-fix-login-auth`, `issue-15-add-export-feature`
 
 ```mermaid
 graph TB
-    subgraph "UI Layer (Fyne)"
-        A[Parts Panel] --> B[App]
-        C[Stock Panel] --> B
-        D[Settings Panel] --> B
-        E[Results Panel] --> B
-        F[Sheet Canvas] --> E
-        G[GCode Preview] --> E
+    subgraph "UI Layer (Fyne) — 2-Tab Layout"
+        subgraph "Tab 1: Layout Editor (HSplit 3-pane)"
+            QS[Quick Settings Panel] --> B[App]
+            SC[Sheet Canvas + Zoom] --> B
+            PS[Parts & Stock Cards] --> B
+        end
+        subgraph "Tab 2: GCode Preview"
+            GP[GCode Simulation Viewport] --> B
+        end
+        AD[Advanced Settings Dialog] --> B
         H[Admin Menu] --> B
     end
 
-    subgraph "Core Engine"
-        B --> I[Optimizer]
+    subgraph "Live Auto-Optimization"
+        B -->|500ms debounce| I[Optimizer]
         I --> J[Guillotine Packer]
         I --> K[Genetic Algorithm]
     end
@@ -157,6 +162,8 @@ graph TB
     style L fill:#e1f5ff
     style Q fill:#fff4e6
     style T fill:#f3e5f5
+    style SC fill:#e1f5ff
+    style QS fill:#f3e5f5
 ```
 
 ## Development Commands

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
   - Structural cut ordering (center-out) to maintain workpiece rigidity during machining
 - **GCode Preview** — Visual toolpath simulation with color-coded rapid/feed/plunge moves
 - **Toolpath Simulation** — Interactive GCode simulation with progress slider, play/pause/stop/step controls, adjustable speed (0.25x-16x), completed vs remaining cut visualization, live tool position indicator, loop playback, and real-time coordinate display (X/Y/Z/Feed/Type)
-- **Live Simulation Viewport** — Embedded simulation tab in the Results panel for instant toolpath visualization without opening a separate dialog
+- **Live Simulation Viewport** — Dedicated GCode Preview tab with instant toolpath visualization
 - **Post-Processor Profiles** — Built-in profiles for Grbl, Mach3, LinuxCNC + custom user profiles
 - **DXF Part Outlines** — GCode follows actual part contours for non-rectangular shapes
 
@@ -50,8 +50,13 @@ A cross-platform desktop application for optimizing rectangular cut lists and ge
 - **Project Save/Load** — JSON-based project files (`.cnccalc`)
 
 ### User Interface
+- **OrcaSlicer-Inspired 2-Tab Layout** — Modern three-pane Layout Editor (quick settings | sheet canvas | parts/stock) and dedicated GCode Preview tab
+- **Live Auto-Optimization** — Debounced 500ms auto-optimize on any settings, parts, or stock change for instant visual feedback
 - **Visual Layout** — Color-coded sheet diagrams showing part placements and stock tab zones
 - **Zoomable Canvas** — Mouse wheel zoom (centered on cursor) and click-and-drag panning on sheet layout views, with zoom in/out buttons and reset
+- **Compact Part & Stock Cards** — Inline add bars, edit/delete actions, and accordion-organized panels
+- **Quick Settings Panel** — Collapsible accordion sections for Tool, Material, Cutting, and Optimizer parameters
+- **Advanced Settings Dialog** — Full CNC settings (optimization weights, GCode profiles, lead-in/out, plunge entry, corner overcuts, onion skinning, toolpath ordering, tabs, clamp zones, dust shoe collision)
 - **Undo/Redo** — Full history with Ctrl+Z / Ctrl+Y (Cmd+Z / Cmd+Shift+Z on macOS)
 - **Parts Library** — Save and reuse predefined parts organized by category
 - **Tool & Stock Inventory** — Manage cutting tools and stock sheet presets
@@ -138,7 +143,8 @@ SlabCut/
 │   │   ├── sharing.go          # Project sharing/collaboration
 │   │   └── appconfig.go        # App config persistence
 │   └── ui/
-│       ├── app.go              # Main UI (tabs, menus, dialogs)
+│       ├── app.go              # Main UI (2-tab layout, menus, dialogs)
+│       ├── advanced_settings.go # Advanced CNC settings dialog
 │       ├── history.go          # Undo/redo history manager
 │       ├── inventory.go        # Inventory management dialogs
 │       ├── library.go          # Parts library dialogs
@@ -159,18 +165,21 @@ SlabCut/
 
 ```mermaid
 graph TB
-    subgraph "UI Layer (Fyne)"
-        A[Parts Panel] --> B[App]
-        C[Stock Panel] --> B
-        D[Settings Panel] --> B
-        E[Results Panel] --> B
-        F[Sheet Canvas] --> E
-        G[GCode Preview] --> E
+    subgraph "UI Layer (Fyne) — 2-Tab Layout"
+        subgraph "Tab 1: Layout Editor (HSplit 3-pane)"
+            QS[Quick Settings Panel] --> B[App]
+            SC[Sheet Canvas + Zoom] --> B
+            PS[Parts & Stock Cards] --> B
+        end
+        subgraph "Tab 2: GCode Preview"
+            GP[GCode Simulation Viewport] --> B
+        end
+        AD[Advanced Settings Dialog] --> B
         H[Admin Menu] --> B
     end
 
-    subgraph "Core Engine"
-        B --> I[Optimizer]
+    subgraph "Live Auto-Optimization"
+        B -->|500ms debounce| I[Optimizer]
         I --> J[Guillotine Packer]
         I --> K[Genetic Algorithm]
     end
@@ -200,6 +209,8 @@ graph TB
     style L fill:#e1f5ff
     style Q fill:#fff4e6
     style T fill:#f3e5f5
+    style SC fill:#e1f5ff
+    style QS fill:#f3e5f5
 ```
 
 ## Contributing

--- a/cmd/slabcut/main.go
+++ b/cmd/slabcut/main.go
@@ -37,7 +37,7 @@ func main() {
 	appUI := ui.NewApp(application, window)
 	appUI.SetupMenus()
 	window.SetContent(appUI.Build())
-	window.Resize(fyne.NewSize(1000, 700))
+	window.Resize(fyne.NewSize(1400, 800))
 	window.CenterOnScreen()
 
 	ui.ShowSplash(application, 2500*time.Millisecond, func() {

--- a/internal/ui/advanced_settings.go
+++ b/internal/ui/advanced_settings.go
@@ -1,0 +1,208 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/piwi3910/SlabCut/internal/model"
+)
+
+// showAdvancedSettingsDialog opens a dialog with all advanced CNC/optimizer settings
+// that are not shown in the quick settings sidebar.
+func (a *App) showAdvancedSettingsDialog() {
+	s := &a.project.Settings
+
+	// Helper to create a bound float entry
+	floatEntry := func(val *float64) *widget.Entry {
+		e := widget.NewEntry()
+		e.SetText(fmt.Sprintf("%.1f", *val))
+		e.OnChanged = func(text string) {
+			if v, err := strconv.ParseFloat(text, 64); err == nil {
+				*val = v
+			}
+		}
+		return e
+	}
+
+	intEntry := func(val *int) *widget.Entry {
+		e := widget.NewEntry()
+		e.SetText(fmt.Sprintf("%d", *val))
+		e.OnChanged = func(text string) {
+			if v, err := strconv.Atoi(text); err == nil {
+				*val = v
+			}
+		}
+		return e
+	}
+
+	// --- Optimization Weights ---
+	weightsSection := widget.NewCard("Optimization Objectives",
+		"Weight priorities for multi-objective optimization (0 = disabled, higher = more important)",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Minimize Waste"), floatEntry(&s.OptimizeWeights.MinimizeWaste),
+			widget.NewLabel("Minimize Sheets"), floatEntry(&s.OptimizeWeights.MinimizeSheets),
+			widget.NewLabel("Minimize Cut Length"), floatEntry(&s.OptimizeWeights.MinimizeCutLen),
+			widget.NewLabel("Minimize Job Time"), floatEntry(&s.OptimizeWeights.MinimizeJobTime),
+		))
+
+	// --- GCode Profile ---
+	profileNames := model.GetProfileNames()
+	profileSelect := widget.NewSelect(profileNames, func(selected string) {
+		s.GCodeProfile = selected
+	})
+	profileSelect.SetSelected(s.GCodeProfile)
+
+	manageProfileBtn := widget.NewButtonWithIcon("Manage Profiles", theme.SettingsIcon(), func() {
+		a.showProfileManager()
+	})
+
+	profileSection := widget.NewCard("GCode Profile", "",
+		container.NewVBox(
+			container.NewGridWithColumns(2,
+				widget.NewLabel("Active Profile"), container.NewBorder(nil, nil, nil, manageProfileBtn, profileSelect),
+			),
+		))
+
+	// --- Lead-In / Lead-Out Arcs ---
+	leadInOutSection := widget.NewCard("Lead-In / Lead-Out Arcs",
+		"Arc approach and exit for smoother cuts",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Lead-In Radius (mm)"), floatEntry(&s.LeadInRadius),
+			widget.NewLabel("Lead-Out Radius (mm)"), floatEntry(&s.LeadOutRadius),
+			widget.NewLabel("Approach Angle (degrees)"), floatEntry(&s.LeadInAngle),
+		))
+
+	// --- Plunge Entry Strategy ---
+	plungeTypeSelect := widget.NewSelect(model.PlungeTypeOptions(), func(selected string) {
+		s.PlungeType = model.PlungeTypeFromString(selected)
+	})
+	plungeTypeSelect.SetSelected(s.PlungeType.String())
+
+	plungeSection := widget.NewCard("Plunge Entry Strategy",
+		"How the tool enters the material",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Plunge Type"), plungeTypeSelect,
+			widget.NewLabel("Ramp Angle (degrees)"), floatEntry(&s.RampAngle),
+			widget.NewLabel("Helix Diameter (mm)"), floatEntry(&s.HelixDiameter),
+			widget.NewLabel("Helix Depth/Rev (%)"), floatEntry(&s.HelixRevPercent),
+		))
+
+	// --- Corner Overcuts ---
+	cornerOvercutSelect := widget.NewSelect(model.CornerOvercutOptions(), func(selected string) {
+		s.CornerOvercut = model.CornerOvercutFromString(selected)
+	})
+	cornerOvercutSelect.SetSelected(s.CornerOvercut.String())
+
+	cornerSection := widget.NewCard("Corner Overcuts",
+		"Relief cuts for square interior corners",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Corner Type"), cornerOvercutSelect,
+		))
+
+	// --- Onion Skinning ---
+	onionSkinCheck := widget.NewCheck("", func(b bool) { s.OnionSkinEnabled = b })
+	onionSkinCheck.Checked = s.OnionSkinEnabled
+	onionCleanupCheck := widget.NewCheck("", func(b bool) { s.OnionSkinCleanup = b })
+	onionCleanupCheck.Checked = s.OnionSkinCleanup
+
+	onionSkinSection := widget.NewCard("Onion Skinning",
+		"Leave thin layer on final pass to prevent part movement",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Enable Onion Skin"), onionSkinCheck,
+			widget.NewLabel("Skin Thickness (mm)"), floatEntry(&s.OnionSkinDepth),
+			widget.NewLabel("Generate Cleanup Pass"), onionCleanupCheck,
+		))
+
+	// --- Toolpath Ordering ---
+	optimizeToolpathCheck := widget.NewCheck("", func(b bool) { s.OptimizeToolpath = b })
+	optimizeToolpathCheck.Checked = s.OptimizeToolpath
+
+	structuralOrderCheck := widget.NewCheck("", func(b bool) { s.StructuralOrdering = b })
+	structuralOrderCheck.Checked = s.StructuralOrdering
+
+	toolpathSection := widget.NewCard("Toolpath Ordering", "",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Optimize Toolpath Order"), optimizeToolpathCheck,
+			widget.NewLabel("Structural Cut Ordering"), structuralOrderCheck,
+			widget.NewLabel("Nesting Rotations (outline parts)"), intEntry(&s.NestingRotations),
+		))
+
+	// --- Stock Holding Tabs ---
+	stockTabEnabled := widget.NewCheck("", func(b bool) { s.StockTabs.Enabled = b })
+	stockTabEnabled.Checked = s.StockTabs.Enabled
+
+	stockTabSection := widget.NewCard("Stock Holding Tabs", "",
+		container.NewVBox(
+			container.NewGridWithColumns(2,
+				widget.NewLabel("Enable Stock Tabs"), stockTabEnabled,
+			),
+			container.NewGridWithColumns(2,
+				widget.NewLabel("Top Padding (mm)"), floatEntry(&s.StockTabs.TopPadding),
+				widget.NewLabel("Bottom Padding (mm)"), floatEntry(&s.StockTabs.BottomPadding),
+				widget.NewLabel("Left Padding (mm)"), floatEntry(&s.StockTabs.LeftPadding),
+				widget.NewLabel("Right Padding (mm)"), floatEntry(&s.StockTabs.RightPadding),
+			),
+		))
+
+	// --- Clamp Zones ---
+	clampZoneListContainer = container.NewVBox()
+	a.refreshClampZoneList()
+
+	addClampBtn := widget.NewButtonWithIcon("Add Clamp Zone", theme.ContentAddIcon(), func() {
+		a.showAddClampZoneDialog()
+	})
+
+	clampZoneSection := widget.NewCard("Fixture / Clamp Zones",
+		"Define exclusion zones where clamps or fixtures are placed on the stock sheet",
+		container.NewVBox(
+			container.NewHBox(layout.NewSpacer(), addClampBtn),
+			clampZoneListContainer,
+		))
+
+	// --- Dust Shoe Collision Detection ---
+	dustShoeCheck := widget.NewCheck("", func(b bool) { s.DustShoeEnabled = b })
+	dustShoeCheck.Checked = s.DustShoeEnabled
+
+	dustShoeSection := widget.NewCard("Dust Shoe Collision Detection",
+		"Detect potential collisions between dust shoe and clamp/fixture zones",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Enable Collision Detection"), dustShoeCheck,
+			widget.NewLabel("Dust Shoe Width (mm)"), floatEntry(&s.DustShoeWidth),
+			widget.NewLabel("Minimum Clearance (mm)"), floatEntry(&s.DustShoeClearance),
+		))
+
+	// --- Part Holding Tabs ---
+	partTabSection := widget.NewCard("Part Holding Tabs",
+		"Tabs to keep parts connected during cut",
+		container.NewGridWithColumns(2,
+			widget.NewLabel("Tab Width (mm)"), floatEntry(&s.PartTabWidth),
+			widget.NewLabel("Tab Height (mm)"), floatEntry(&s.PartTabHeight),
+			widget.NewLabel("Tabs per Side"), intEntry(&s.PartTabsPerSide),
+		))
+
+	// Assemble all sections into a scrollable layout
+	content := container.NewVScroll(container.NewVBox(
+		weightsSection,
+		profileSection,
+		toolpathSection,
+		plungeSection,
+		leadInOutSection,
+		cornerSection,
+		onionSkinSection,
+		partTabSection,
+		stockTabSection,
+		clampZoneSection,
+		dustShoeSection,
+	))
+
+	d := dialog.NewCustom("Advanced Settings", "Close", content, a.window)
+	d.Resize(fyne.NewSize(650, 700))
+	d.Show()
+}

--- a/internal/ui/inventory.go
+++ b/internal/ui/inventory.go
@@ -532,9 +532,8 @@ func (a *App) buildToolProfileSelector() fyne.CanvasObject {
 			return
 		}
 		tool.ApplyToSettings(&a.project.Settings)
-		// Rebuild the settings panel to reflect new values
-		a.tabs.Items[2].Content = a.buildSettingsPanel()
-		a.tabs.Refresh()
+		// Rebuild the layout editor to reflect new tool values
+		a.rebuildSettingsPanel()
 	})
 	toolSelect.PlaceHolder = "Load from Tool Profile..."
 

--- a/internal/ui/widgets/sheet_canvas.go
+++ b/internal/ui/widgets/sheet_canvas.go
@@ -52,7 +52,7 @@ type SheetCanvas struct {
 	dragging bool
 	dragX    float32 // last drag position
 	dragY    float32
-	dirty    bool    // set when sheet data changes, forces renderer rebuild
+	dirty    bool // set when sheet data changes, forces renderer rebuild
 }
 
 // NewSheetCanvas creates a new zoomable, pannable sheet canvas widget.

--- a/internal/ui/widgets/sheet_canvas.go
+++ b/internal/ui/widgets/sheet_canvas.go
@@ -52,6 +52,7 @@ type SheetCanvas struct {
 	dragging bool
 	dragX    float32 // last drag position
 	dragY    float32
+	dirty    bool    // set when sheet data changes, forces renderer rebuild
 }
 
 // NewSheetCanvas creates a new zoomable, pannable sheet canvas widget.
@@ -123,6 +124,16 @@ func (sc *SheetCanvas) MouseMoved(ev *desktop.MouseEvent) {
 	sc.dragX = ev.Position.X
 	sc.dragY = ev.Position.Y
 
+	sc.Refresh()
+}
+
+// SetSheet updates the displayed sheet and settings, then refreshes the canvas.
+func (sc *SheetCanvas) SetSheet(sheet model.SheetResult, settings model.CutSettings) {
+	sc.mu.Lock()
+	sc.sheet = sheet
+	sc.settings = settings
+	sc.dirty = true
+	sc.mu.Unlock()
 	sc.Refresh()
 }
 
@@ -389,9 +400,13 @@ func (r *sheetCanvasRenderer) Layout(size fyne.Size) {}
 func (r *sheetCanvasRenderer) Refresh() {
 	r.sc.mu.Lock()
 	z, px, py := r.sc.zoom, r.sc.panX, r.sc.panY
+	dirty := r.sc.dirty
+	if dirty {
+		r.sc.dirty = false
+	}
 	r.sc.mu.Unlock()
-	// Only rebuild when zoom/pan actually changed
-	if r.built && z == r.lastZoom && px == r.lastPanX && py == r.lastPanY {
+	// Only rebuild when zoom/pan actually changed or data is dirty
+	if r.built && !dirty && z == r.lastZoom && px == r.lastPanX && py == r.lastPanY {
 		return
 	}
 	r.rebuild()


### PR DESCRIPTION
## Summary

Major UI redesign replacing the 4-tab layout (Parts | Stock | Settings | Results) with an OrcaSlicer-inspired 2-tab design:

- **Tab 1 "Layout Editor"**: Three-pane layout with quick settings accordion (left), interactive SheetCanvas with zoom/pan (center), and compact parts/stock cards (right)
- **Tab 2 "GCode Preview"**: Full GCode toolpath visualization with simulation controls (play/pause/step/speed)
- **Live auto-optimization**: 500ms debounced optimization triggers automatically on any change to parts, stock, or settings
- **Advanced Settings dialog**: Rarely-changed settings (lead-in/out, onion skin, clamp zones, dust shoe, etc.) moved to dedicated dialog
- **Status bar**: Version info, optimization summary, quick export buttons

### Key Changes
- `internal/ui/app.go` — Major rewrite: new `Build()`, three-pane layout, auto-optimize, compact card-based parts/stock display
- `internal/ui/advanced_settings.go` — New file: extracted advanced settings into standalone dialog
- `internal/ui/widgets/sheet_canvas.go` — Added `SetSheet()` method for dynamic updates
- `internal/ui/inventory.go` — Fixed stale tab reference
- `cmd/slabcut/main.go` — Window size 1000x700 → 1400x800
- `CLAUDE.md` + `README.md` — Updated architecture diagrams and feature lists

### What's Preserved
- All model types unchanged
- All dialogs (add/edit part, add/edit stock, etc.) preserved
- Engine/optimizer code unchanged
- GCode generator unchanged
- Import/export unchanged
- Inventory/library/template persistence unchanged
- Undo/redo system unchanged

## Test plan
- [x] `go build ./cmd/slabcut` compiles successfully
- [x] `go test ./...` all tests pass
- [x] `gofmt -l .` no formatting issues
- [ ] Manual testing: launch app, verify three-pane layout renders correctly
- [ ] Manual testing: add parts via quick-add, verify auto-optimization triggers
- [ ] Manual testing: switch to GCode Preview tab, verify simulation controls work
- [ ] Manual testing: open Advanced Settings dialog, verify all settings present

Resolves #103